### PR TITLE
Remove yarpdev in favour of yarprobotinterface

### DIFF
--- a/app/5g_Tours_R1SN003_CRIS_SHORT_faceTempFix.xml
+++ b/app/5g_Tours_R1SN003_CRIS_SHORT_faceTempFix.xml
@@ -1,0 +1,42 @@
+<application>
+  <name>5g_Tours_R1SN003_CRIS_SHORT_faceTempFix</name>
+
+  <application>
+    <name>Navigation_ROS2_R1SN003</name>
+    <prefix></prefix>
+  </application>
+
+  <application>
+    <name>headSynchronizer</name>
+    <prefix></prefix>
+  </application>
+
+  <application>
+    <name>vad_faceTempFix</name>
+    <prefix></prefix>
+  </application>
+
+  <application>
+    <name>google</name>
+    <prefix></prefix>
+  </application>
+
+  <application>
+    <name>open_pose_stuff</name>
+    <prefix></prefix>
+  </application>
+
+  <application>
+    <name>btStructure_cer</name>
+    <prefix></prefix>
+  </application>
+
+  <application>
+    <name>tourManagerApp_CRIS_SHORT</name>
+    <prefix></prefix>
+  </application>
+
+  <dependencies>
+  </dependencies>
+
+</application>

--- a/app/btStructure/CMakeLists.txt
+++ b/app/btStructure/CMakeLists.txt
@@ -7,11 +7,13 @@
 
 set(appname btStructure)
 
-file(GLOB conf      ${CMAKE_CURRENT_SOURCE_DIR}/conf/*.ini)
-file(GLOB apps      ${CMAKE_CURRENT_SOURCE_DIR}/scripts/*.xml)
-file(GLOB trees      ${CMAKE_CURRENT_SOURCE_DIR}/trees/*.xml)
+file(GLOB conf            ${CMAKE_CURRENT_SOURCE_DIR}/conf/*.ini)
+file(GLOB apps            ${CMAKE_CURRENT_SOURCE_DIR}/scripts/*.xml)
+file(GLOB trees           ${CMAKE_CURRENT_SOURCE_DIR}/trees/*.xml)
+file(GLOB robotInterface  ${CMAKE_CURRENT_SOURCE_DIR}/conf/robotInterface/*.xml)
 
 yarp_install(FILES ${conf}    DESTINATION ${BEHAVIOR-TOUR-ROBOT_CONTEXTS_INSTALL_DIR}/${appname})
 # For trees xml's and help files it would be nice to have two different folders (like for Contexts and applications)
 yarp_install(FILES ${trees}    DESTINATION ${BEHAVIOR-TOUR-ROBOT_CONTEXTS_INSTALL_DIR}/${appname}/trees)
 yarp_install(FILES ${apps}    DESTINATION ${BEHAVIOR-TOUR-ROBOT_APPLICATIONS_INSTALL_DIR})
+yarp_install(FILES ${robotInterface}    DESTINATION ${BEHAVIOR-TOUR-ROBOT_CONTEXTS_INSTALL_DIR}/${appname}/robotInterface)

--- a/app/btStructure/conf/battery.ini
+++ b/app/btStructure/conf/battery.ini
@@ -1,0 +1,1 @@
+config robotInterface/battery.xml

--- a/app/btStructure/conf/robotInterface/battery.xml
+++ b/app/btStructure/conf/robotInterface/battery.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+SPDX-License-Identifier: BSD-3-Clause
+-->
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<robot name="batteryDev" build="2" portprefix="" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<devices>
+		<device name="battery" type="fakeBattery">
+			<param extern-name="battery_charge" name="charge">
+				50
+			</param>
+		</device>
+
+        <device name="batteryWrap" type="batteryWrapper">
+            <param extern-name="battery_name" name="name">
+				/battery
+			</param>
+			<action phase="startup" level="5" type="attach">
+				<paramlist name="networks">
+					<elem name="subdevicebattery">
+						battery
+					</elem>
+				</paramlist>
+			</action>
+			<action phase="shutdown" level="5" type="detach" />
+		</device>
+	</devices>
+</robot>

--- a/app/btStructure/scripts/BtStructure_cer.xml
+++ b/app/btStructure/scripts/BtStructure_cer.xml
@@ -4,8 +4,8 @@
   <dependencies></dependencies>
 
   <module>
-    <name>yarpdev</name>
-    <parameters>--device batteryWrapper --subdevice fakeBattery --name /battery --charge 50</parameters>
+    <name>yarprobotinterface</name>
+    <parameters>--context btStructure --from battery.ini</parameters>
     <node>r1-base</node>
   </module>
 

--- a/app/btStructure/scripts/BtStructure_sim_cer_robot.xml
+++ b/app/btStructure/scripts/BtStructure_sim_cer_robot.xml
@@ -3,10 +3,10 @@
 
   <dependencies></dependencies>
 
-   <module>
-    <name>yarpdev</name>
-    <parameters>--device batteryWrapper --subdevice fakeBattery --name /battery --charge 50</parameters>
-    <node>console1</node>
+  <module>
+    <name>yarprobotinterface</name>
+    <parameters>--context btStructure --from battery.ini</parameters>
+    <node>r1-base</node>
   </module>
 
   <module>

--- a/app/btStructure/scripts/BtStructure_sim_cer_robot.xml
+++ b/app/btStructure/scripts/BtStructure_sim_cer_robot.xml
@@ -6,7 +6,7 @@
   <module>
     <name>yarprobotinterface</name>
     <parameters>--context btStructure --from battery.ini</parameters>
-    <node>r1-base</node>
+    <node>console1</node>
   </module>
 
   <module>

--- a/app/headSynchronizer/CMakeLists.txt
+++ b/app/headSynchronizer/CMakeLists.txt
@@ -8,5 +8,9 @@
 set(appname headSynchronizer)
 
 file(GLOB apps      ${CMAKE_CURRENT_SOURCE_DIR}/scripts/*.xml)
+file(GLOB conf      ${CMAKE_CURRENT_SOURCE_DIR}/conf/*.ini)
+file(GLOB robotInterface      ${CMAKE_CURRENT_SOURCE_DIR}/conf/robotInterface/*.xml)
 
 yarp_install(FILES ${apps}    DESTINATION ${BEHAVIOR-TOUR-ROBOT_APPLICATIONS_INSTALL_DIR})
+yarp_install(FILES ${conf}    DESTINATION ${BEHAVIOR-TOUR-ROBOT_CONTEXTS_INSTALL_DIR}/${appname})
+yarp_install(FILES ${robotInterface}    DESTINATION ${BEHAVIOR-TOUR-ROBOT_CONTEXTS_INSTALL_DIR}/${appname}/robotInterface)

--- a/app/headSynchronizer/conf/faceDisplay.ini
+++ b/app/headSynchronizer/conf/faceDisplay.ini
@@ -1,0 +1,1 @@
+config robotInterface/faceDisplay.xml

--- a/app/headSynchronizer/conf/robotInterface/faceDisplay.xml
+++ b/app/headSynchronizer/conf/robotInterface/faceDisplay.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+SPDX-License-Identifier: BSD-3-Clause
+-->
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<robot name="faceDisplayDev" build="2" portprefix="" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<devices>
+		<device name="faceDisplay" type="faceDisplayServer">
+		</device>
+	</devices>
+</robot>

--- a/app/headSynchronizer/scripts/headSynchronizer.xml
+++ b/app/headSynchronizer/scripts/headSynchronizer.xml
@@ -3,10 +3,10 @@
 
   <dependencies>
   </dependencies>
-  
+
   <module>
-    <name>yarpdev </name>
-    <parameters>--device faceDisplayServer</parameters>
+    <name>yarprobotinterface </name>
+    <parameters>--context headSynchronizer --from faceDisplay.ini</parameters>
     <node>r1-face</node>
   </module>
 
@@ -33,7 +33,7 @@
     <parameters></parameters>
     <node>console1</node>
   </module>
-    
+
   <connection>
     <from>/faceExpressionImage/image:o</from>
     <to>/robot/faceDisplay/image:i</to>
@@ -87,7 +87,7 @@
     <to>/HeadSynchronizer/thrift:s</to>
     <protocol>fast_tcp</protocol>
   </connection>
-  
+
   <connection>
     <from>/vad/HeadSynchronizer/thrift:c</from>
     <to>/HeadSynchronizer/thrift:s</to>

--- a/app/navigation2/conf/navigator2D.ini
+++ b/app/navigation2/conf/navigator2D.ini
@@ -1,0 +1,1 @@
+config robotInterface/navigator2D.xml

--- a/app/navigation2/conf/robotInterface/navigator2D.xml
+++ b/app/navigation2/conf/robotInterface/navigator2D.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+SPDX-License-Identifier: BSD-3-Clause
+-->
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<robot name="navigation2DServer" build="2" portprefix="" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<devices>
+		<device name="navigatorRos2" type="ros2Navigator">
+		</device>
+
+		<device name="nav2DNwsYarp" type="navigation2D_nws_yarp">
+			<action phase="startup" level="5" type="attach">
+				<paramlist name="networks">
+					<elem name="subdeviceRos2Nav">
+						navigatorRos2
+					</elem>
+				</paramlist>
+			</action>
+			<action phase="shutdown" level="5" type="detach" />
+		</device>
+	</devices>
+</robot>

--- a/app/navigation2/scripts/Navigation_ROS2_R1SN001.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1SN001.xml
@@ -83,8 +83,8 @@
    </module>
 
    <module>
-      <name>yarpdev</name>
-      <parameters>--device navigation2D_nws_yarp --subdevice ros2Navigator</parameters>
+      <name>yarprobotinterface</name>
+      <parameters>--context navigation2 --from navigator2D.ini</parameters>
       <node>console</node>
    </module>
 

--- a/app/navigation2/scripts/Navigation_ROS2_R1SN003.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1SN003.xml
@@ -90,15 +90,15 @@
    </module>
 
    <module>
+
       <name>ros2</name>
       <parameters>launch launch/costmap_filter_info.launch.py params_file:=conf/cris_new_area_fixed_keepout_params.yaml mask:=/home/user1/tour-guide-robot/app/maps/cris_new_area_fixed_keepout_mask.yaml</parameters>
       <workdir>/home/user1/tour-guide-robot/app/navigation2/</workdir>
       <node>console</node>
    </module>
-   
-   <module>
-      <name>yarpdev</name>
-      <parameters>--device navigation2D_nws_yarp --subdevice ros2Navigator</parameters>
+
+      <name>yarprobotinterface</name>
+      <parameters>--context navigation2 --from navigator2D.ini</parameters>
       <node>console</node>
    </module>
 

--- a/app/navigation2/scripts/Navigation_ROS2_R1SN003.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1SN003.xml
@@ -97,6 +97,7 @@
       <node>console</node>
    </module>
 
+   <module>
       <name>yarprobotinterface</name>
       <parameters>--context navigation2 --from navigator2D.ini</parameters>
       <node>console</node>

--- a/app/navigation2/scripts/Navigation_ROS2_R1_SIM.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1_SIM.xml
@@ -30,13 +30,13 @@
       <parameters>--context navigation2 --from pointCloudCreator_sim.ini</parameters>
       <node>console</node>
    </module>
-   
+
    <module>
       <name>yarprobotinterface</name>
       <parameters>--context navigation2 --from lidar_compressed_sim.ini</parameters>
       <node>console</node>
    </module>
-   
+
    <module>
       <name>yarprobotinterface</name>
       <parameters>--context navigation2 --from mapServer.ini</parameters>
@@ -49,7 +49,7 @@
       <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
       <node>console</node>
    </module>
-   
+
    <module>
       <name>yarprobotinterface</name>
       <parameters>--context navigation2 --from localizationROS2.ini --init_map gam_sim_real</parameters>
@@ -62,7 +62,7 @@
       <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
       <node>console</node>
    </module>
-   
+
    <module>
       <name>ros2</name>
       <parameters>launch costmap_filter_info.launch.py params_file:=../conf/gam_sim_real_keepout_params.yaml mask:=../../maps/gam_sim_real_keepout_mask.yaml use_sim_time:=true</parameters>
@@ -71,11 +71,11 @@
    </module>
 
    <module>
-      <name>yarpdev</name>
-      <parameters>--device navigation2D_nws_yarp --subdevice ros2Navigator</parameters>
+      <name>yarprobotinterface</name>
+      <parameters>--context navigation2 --from navigator2D.ini</parameters>
       <node>console</node>
    </module>
-   
+
    <module>
       <name>headObstaclesScanner</name>
       <parameters>--GENERAL::robot SIM_CER_ROBOT --GENERAL::head_mode trajectory --GENERAL::autoconnect --GENERAL::head_pitch 10 --HEAD::circle_range 1</parameters>

--- a/app/openPoseStuff/scripts/open_pose_app.xml
+++ b/app/openPoseStuff/scripts/open_pose_app.xml
@@ -14,7 +14,7 @@
 	<module>
 		<name>python3</name>
 		<parameters>/home/user1/robotology/iCubContrib/bin/multiface-mutualgaze-classifier.py --context mutual-gaze-classifier-demo --from classifier_conf.ini</parameters>
-		<node>console1</node>
+		<node>console3</node>
 	</module>
 
 	<!-- <module>
@@ -22,7 +22,7 @@
 		<parameters>--context openPoseStuff --from skeleton.ini --transformClient::rootFrameName depth_center --camera::fov "(86 57)"</parameters>
 		<node>console</node>
 	</module> -->
-   
+
 	<module>
 		<name>yarpview</name>
 		<parameters>--name /view/rgb --w 640 --h 480</parameters>
@@ -81,7 +81,7 @@
 		<from>/yarpOpenPose/float:o</from>
 		<to>/skeletonRetriever/depth:i</to>
 		<protocol>fast_tcp</protocol>
-	</connection> 
+	</connection>
 
 	<connection>
 		<from>/yarpOpenPose/target:o</from>

--- a/app/voiceActivationDetection/CMakeLists.txt
+++ b/app/voiceActivationDetection/CMakeLists.txt
@@ -8,6 +8,9 @@
 set(appname vadModule)
 
 file(GLOB apps      ${CMAKE_CURRENT_SOURCE_DIR}/scripts/*.xml)
+file(GLOB conf      ${CMAKE_CURRENT_SOURCE_DIR}/conf/*.ini)
+file(GLOB robotInterface      ${CMAKE_CURRENT_SOURCE_DIR}/conf/robotInterface/*.xml)
 
 yarp_install(FILES ${apps}    DESTINATION ${BEHAVIOR-TOUR-ROBOT_APPLICATIONS_INSTALL_DIR})
-
+yarp_install(FILES ${conf}    DESTINATION ${BEHAVIOR-TOUR-ROBOT_CONTEXTS_INSTALL_DIR}/${appname})
+yarp_install(FILES ${robotInterface}    DESTINATION ${BEHAVIOR-TOUR-ROBOT_CONTEXTS_INSTALL_DIR}/${appname}/robotInterface)

--- a/app/voiceActivationDetection/conf/audioPlayer.ini
+++ b/app/voiceActivationDetection/conf/audioPlayer.ini
@@ -1,0 +1,1 @@
+config robotInterface/audioPlayer.xml

--- a/app/voiceActivationDetection/conf/audioPlayerToFileFiltered.ini
+++ b/app/voiceActivationDetection/conf/audioPlayerToFileFiltered.ini
@@ -1,0 +1,1 @@
+--config robotInterface/audioPlayerToFileFiltered.xml

--- a/app/voiceActivationDetection/conf/audioPlayerToFileFiltered.ini
+++ b/app/voiceActivationDetection/conf/audioPlayerToFileFiltered.ini
@@ -1,1 +1,1 @@
---config robotInterface/audioPlayerToFileFiltered.xml
+config robotInterface/audioPlayerToFileFiltered.xml

--- a/app/voiceActivationDetection/conf/audioPlayerToFileOrig.ini
+++ b/app/voiceActivationDetection/conf/audioPlayerToFileOrig.ini
@@ -1,1 +1,1 @@
---config robotInterface/audioPlayerToFileOrig.xml
+config robotInterface/audioPlayerToFileOrig.xml

--- a/app/voiceActivationDetection/conf/audioPlayerToFileOrig.ini
+++ b/app/voiceActivationDetection/conf/audioPlayerToFileOrig.ini
@@ -1,0 +1,1 @@
+--config robotInterface/audioPlayerToFileOrig.xml

--- a/app/voiceActivationDetection/conf/audioRecorder.ini
+++ b/app/voiceActivationDetection/conf/audioRecorder.ini
@@ -1,0 +1,1 @@
+config robotInterface/audioRecorder.xml

--- a/app/voiceActivationDetection/conf/audioRecorderAutoStart.ini
+++ b/app/voiceActivationDetection/conf/audioRecorderAutoStart.ini
@@ -1,0 +1,1 @@
+config robotInterface/audioRecorderAutoStart.xml

--- a/app/voiceActivationDetection/conf/audioRecorderFromFile.ini
+++ b/app/voiceActivationDetection/conf/audioRecorderFromFile.ini
@@ -1,0 +1,1 @@
+config robotInterface/audioRecorderFromFile.xml

--- a/app/voiceActivationDetection/conf/robotInterface/audioPlayer.xml
+++ b/app/voiceActivationDetection/conf/robotInterface/audioPlayer.xml
@@ -16,6 +16,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
         <device name="audioPlayWrap" type="AudioPlayerWrapper">
             <param extern-name="play_start" name="start">
+                true
             </param>
             <param extern-name="play_playback_network_buffer_size" name="playback_network_buffer_size">
                 0.1

--- a/app/voiceActivationDetection/conf/robotInterface/audioPlayer.xml
+++ b/app/voiceActivationDetection/conf/robotInterface/audioPlayer.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+SPDX-License-Identifier: BSD-3-Clause
+-->
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<robot name="audioPlayerDev" build="2" portprefix="" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <device name="portPlay" type="portaudioPlayer">
+            <group name="AUDIO_BASE">
+                <param extern-name="play_base_samples" name="samples">
+                    1323000
+                </param>
+            </group>
+        </device>
+
+        <device name="audioPlayWrap" type="AudioPlayerWrapper">
+            <param extern-name="play_start" name="start">
+            </param>
+            <param extern-name="play_playback_network_buffer_size" name="playback_network_buffer_size">
+                0.1
+            </param>
+            <action phase="startup" level="5" type="attach">
+                <paramlist name="networks">
+                    <elem name="subdeviceaudoplay">
+                        portPlay
+                    </elem>
+                </paramlist>
+            </action>
+            <action phase="shutdown" level="5" type="detach" />
+        </device>
+    </devices>
+</robot>

--- a/app/voiceActivationDetection/conf/robotInterface/audioPlayerToFileFiltered.xml
+++ b/app/voiceActivationDetection/conf/robotInterface/audioPlayerToFileFiltered.xml
@@ -22,6 +22,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
         <device name="toFileFilteredPlayWrap" type="AudioPlayerWrapper">
             <param extern-name="toFileFiltered_start" name="start">
+                true
             </param>
             <param extern-name="toFileFiltered_playback_network_buffer_size" name="playback_network_buffer_size">
                 0.1

--- a/app/voiceActivationDetection/conf/robotInterface/audioPlayerToFileFiltered.xml
+++ b/app/voiceActivationDetection/conf/robotInterface/audioPlayerToFileFiltered.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+SPDX-License-Identifier: BSD-3-Clause
+-->
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<robot name="audioPlayerFileFilteredDev" build="2" portprefix="" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <device name="toFileFilteredPlay" type="audioToFileDevice">
+            <group name="AUDIO_BASE">
+                <param extern-name="toFileFiltered_base_samples" name="samples">
+                    1323000
+                </param>
+            </group>
+            <param extern-name="toFileFiltered_fileName" name="file_name">
+                filtered.wav
+            </param>
+            <param extern-name="toFileFiltered_saveMode" name="save_mode">
+                overwrite_file
+            </param>
+        </device>
+
+        <device name="toFileFilteredPlayWrap" type="AudioPlayerWrapper">
+            <param extern-name="toFileFiltered_start" name="start">
+            </param>
+            <param extern-name="toFileFiltered_playback_network_buffer_size" name="playback_network_buffer_size">
+                0.1
+            </param>
+            <param extern-name="toFileFiltered_name" name="name">
+                /filtered
+            </param>
+            <action phase="startup" level="5" type="attach">
+                <paramlist name="networks">
+                    <elem name="subdevicetofileorig">
+                        toFileFilteredPlay
+                    </elem>
+                </paramlist>
+            </action>
+            <action phase="shutdown" level="5" type="detach" />
+        </device>
+    </devices>
+</robot>

--- a/app/voiceActivationDetection/conf/robotInterface/audioPlayerToFileOrig.xml
+++ b/app/voiceActivationDetection/conf/robotInterface/audioPlayerToFileOrig.xml
@@ -22,6 +22,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
         <device name="toFileOrigPlayWrap" type="AudioPlayerWrapper">
             <param extern-name="toFileOrig_start" name="start">
+                true
             </param>
             <param extern-name="toFileOrig_playback_network_buffer_size" name="playback_network_buffer_size">
                 0.1

--- a/app/voiceActivationDetection/conf/robotInterface/audioPlayerToFileOrig.xml
+++ b/app/voiceActivationDetection/conf/robotInterface/audioPlayerToFileOrig.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+SPDX-License-Identifier: BSD-3-Clause
+-->
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<robot name="audioPlayerFileOrigDev" build="2" portprefix="" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <device name="toFileOrigPlay" type="audioToFileDevice">
+            <group name="AUDIO_BASE">
+                <param extern-name="toFileOrig_base_samples" name="samples">
+                    1323000
+                </param>
+            </group>
+            <param extern-name="toFileOrig_fileName" name="file_name">
+                original.wav
+            </param>
+            <param extern-name="toFileOrig_saveMode" name="save_mode">
+                overwrite_file
+            </param>
+        </device>
+
+        <device name="toFileOrigPlayWrap" type="AudioPlayerWrapper">
+            <param extern-name="toFileOrig_start" name="start">
+            </param>
+            <param extern-name="toFileOrig_playback_network_buffer_size" name="playback_network_buffer_size">
+                0.1
+            </param>
+            <param extern-name="toFileOrig_name" name="name">
+                /original
+            </param>
+            <action phase="startup" level="5" type="attach">
+                <paramlist name="networks">
+                    <elem name="subdevicetofileorig">
+                        toFileOrigPlay
+                    </elem>
+                </paramlist>
+            </action>
+            <action phase="shutdown" level="5" type="detach" />
+        </device>
+    </devices>
+</robot>

--- a/app/voiceActivationDetection/conf/robotInterface/audioRecorder.xml
+++ b/app/voiceActivationDetection/conf/robotInterface/audioRecorder.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+SPDX-License-Identifier: BSD-3-Clause
+-->
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<robot name="audioRecorderDev" build="2" portprefix="" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <device name="portRec" type="portaudioRecorder">
+            <group name="AUDIO_BASE">
+                <param extern-name="rec_base_rate" name="rate">
+                    44100
+                </param>
+                <param extern-name="rec_base_samples" name="samples">
+                    17640
+                </param>
+                <param extern-name="rec_base_channels" name="channels">
+                    1
+                </param>
+            </group>
+        </device>
+
+        <device name="audioRecWrap" type="AudioRecorderWrapper">
+            <param extern-name="rec_min_samples_over_network" name="min_samples_over_network">
+                8820
+            </param>
+            <param extern-name="rec_max_samples_over_network" name="max_samples_over_network">
+                8820
+            </param>
+            <action phase="startup" level="5" type="attach">
+                <paramlist name="networks">
+                    <elem name="subdeviceaudorec">
+                        portRec
+                    </elem>
+                </paramlist>
+            </action>
+            <action phase="shutdown" level="5" type="detach" />
+        </device>
+    </devices>
+</robot>

--- a/app/voiceActivationDetection/conf/robotInterface/audioRecorderAutoStart.xml
+++ b/app/voiceActivationDetection/conf/robotInterface/audioRecorderAutoStart.xml
@@ -22,6 +22,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
         <device name="audioAutoRecWrap" type="AudioRecorderWrapper">
             <param extern-name="autoRec_start" name="start">
+                true
             </param>
             <param extern-name="autoRec_min_samples_over_network" name="min_samples_over_network">
                 8820

--- a/app/voiceActivationDetection/conf/robotInterface/audioRecorderAutoStart.xml
+++ b/app/voiceActivationDetection/conf/robotInterface/audioRecorderAutoStart.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+SPDX-License-Identifier: BSD-3-Clause
+-->
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<robot name="audioRecAutoDev" build="2" portprefix="" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <device name="portAutoRec" type="portaudioRecorder">
+            <group name="AUDIO_BASE">
+                <param extern-name="autoRec_base_rate" name="rate">
+                    44100
+                </param>
+                <param extern-name="autoRec_base_samples" name="samples">
+                    17640
+                </param>
+                <param extern-name="autoRec_base_channels" name="channels">
+                    1
+                </param>
+            </group>
+        </device>
+
+        <device name="audioAutoRecWrap" type="AudioRecorderWrapper">
+            <param extern-name="autoRec_start" name="start">
+            </param>
+            <param extern-name="autoRec_min_samples_over_network" name="min_samples_over_network">
+                8820
+            </param>
+            <param extern-name="autoRec_max_samples_over_network" name="max_samples_over_network">
+                8820
+            </param>
+            <action phase="startup" level="5" type="attach">
+                <paramlist name="networks">
+                    <elem name="subdeviceaudoautorec">
+                        portAutoRec
+                    </elem>
+                </paramlist>
+            </action>
+            <action phase="shutdown" level="5" type="detach" />
+        </device>
+    </devices>
+</robot>

--- a/app/voiceActivationDetection/conf/robotInterface/audioRecorderFromFile.xml
+++ b/app/voiceActivationDetection/conf/robotInterface/audioRecorderFromFile.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+SPDX-License-Identifier: BSD-3-Clause
+-->
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<robot name="fromFileRecorderDev" build="2" portprefix="" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <device name="fromFileRec" type="audioFromFileDevice">
+            <group name="AUDIO_BASE">
+                <param extern-name="fromFile_base_rate" name="rate">
+                    44100
+                </param>
+                <param extern-name="fromFile_base_samples" name="samples">
+                    17640
+                </param>
+                <param extern-name="fromFile_base_channels" name="channels">
+                    1
+                </param>
+            </group>
+            <param extern-name="fromFile_fileName" name="file_name">
+                internal_75vol_far_alone.wav
+            </param>
+        </device>
+
+        <device name="fromFileRecWrap" type="AudioRecorderWrapper">
+            <param extern-name="fromFile_min_samples_over_network" name="min_samples_over_network">
+                8820
+            </param>
+            <param extern-name="fromFile_max_samples_over_network" name="max_samples_over_network">
+                8820
+            </param>
+            <action phase="startup" level="5" type="attach">
+                <paramlist name="networks">
+                    <elem name="subdeviceaudiofromfile">
+                        fromFileRec
+                    </elem>
+                </paramlist>
+            </action>
+            <action phase="shutdown" level="5" type="detach" />
+        </device>
+    </devices>
+</robot>

--- a/app/voiceActivationDetection/scripts/test-on-Audio.xml
+++ b/app/voiceActivationDetection/scripts/test-on-Audio.xml
@@ -9,34 +9,34 @@
   <!-- recording audio from microphone -->
   <module>
     <name>yarprobotinterface</name>
-    <parameters>--context voiceActivationDetection --from audioRecorderAutoStart.ini</parameters>
+    <parameters>--context vadModule --from audioRecorderAutoStart.ini</parameters>
     <node>console</node>
   </module>
 
   <!-- saving the original audio received from the port to original.wav -->
   <module>
     <name>yarprobotinterface</name>
-    <parameters>--context voiceActivationDetection --from audioPlayerToFileOrig.ini</parameters>
+    <parameters>--context vadModule --from audioPlayerToFileOrig.ini</parameters>
     <node>console</node>
   </module>
 
   <!-- saving the filtered audio received from the port to filtered.wav -->
   <module>
     <name>yarprobotinterface</name>
-    <parameters>--context voiceActivationDetection --from audioPlayerToFileFiltered.ini</parameters>
+    <parameters>--context vadModule --from audioPlayerToFileFiltered.ini</parameters>
     <node>console</node>
   </module>
 
   <module>
     <name>yarprobotinterface</name>
-    <parameters>--context voiceActivationDetection --from audioPlayer.ini</parameters>
+    <parameters>--context vadModule --from audioPlayer.ini</parameters>
     <node>console</node>
   </module>
 
   <!-- playing the audio from the file original.wav to a port -->
   <module>
     <name>yarprobotinterface</name>
-    <parameters>--context voiceActivationDetection --from audioRecorderFromFile.ini</parameters>
+    <parameters>--context vadModule --from audioRecorderFromFile.ini</parameters>
     <node>console</node>
   </module>
 
@@ -47,7 +47,7 @@
   </module>
 
   <module>
-    <name>voiceActivationDetection</name>
+    <name>vadModule</name>
     <parameters>--</parameters>
     <node>console</node>
   </module>

--- a/app/voiceActivationDetection/scripts/test-on-Audio.xml
+++ b/app/voiceActivationDetection/scripts/test-on-Audio.xml
@@ -6,71 +6,72 @@
 
 
 
-    <!-- recording audio from microphone -->
+  <!-- recording audio from microphone -->
   <module>
-    <name>yarpdev</name>
-    <parameters>--device AudioRecorderWrapper --subdevice portaudioRecorder --min_samples_over_network 8820 --max_samples_over_network 8820 --AUDIO_BASE::rate 44100 --AUDIO_BASE::samples 17640 --AUDIO_BASE::channels 1  --start</parameters>
+    <name>yarprobotinterface</name>
+    <parameters>--context voiceActivationDetection --from audioRecorderAutoStart.ini</parameters>
     <node>console</node>
   </module>
 
-    <!-- saving the original audio received from the port to original.wav -->
+  <!-- saving the original audio received from the port to original.wav -->
   <module>
-    <name>yarpdev</name>
-    <parameters>--device AudioPlayerWrapper --subdevice audioToFileDevice --save_mode overwrite_file --file_name original.wav --name /original ---playback_network_buffer_size 0.1 --AUDIO_BASE::samples 1323000 --start</parameters>
+    <name>yarprobotinterface</name>
+    <parameters>--context voiceActivationDetection --from audioPlayerToFileOrig.ini</parameters>
     <node>console</node>
   </module>
 
-    <!-- saving the filtered audio received from the port to filtered.wav -->
-    <module>
-        <name>yarpdev</name>
-        <parameters>--device AudioPlayerWrapper --subdevice audioToFileDevice --save_mode overwrite_file --file_name filtered.wav --name /filtered --playback_network_buffer_size 0.1 --AUDIO_BASE::samples 1323000 --start</parameters>
-        <node>console</node>
-    </module>
-
-    <module>
-        <name>yarpdev</name>
-        <parameters>--device AudioPlayerWrapper --subdevice portaudioPlayer --start --playback_network_buffer_size 0.1 --AUDIO_BASE::samples 1323000</parameters>
-        <node>console</node>
-    </module>
-    <!-- playing the audio from the file original.wav to a port -->
+  <!-- saving the filtered audio received from the port to filtered.wav -->
   <module>
-    <name>yarpdev</name>
-    <parameters>--device AudioRecorderWrapper --subdevice audioFromFileDevice --file_name internal_75vol_far_alone.wav  --min_samples_over_network 8820 --max_samples_over_network 8820 --AUDIO_BASE::rate 44100 --AUDIO_BASE::samples 17640 --AUDIO_BASE::channels 1</parameters>
+    <name>yarprobotinterface</name>
+    <parameters>--context voiceActivationDetection --from audioPlayerToFileFiltered.ini</parameters>
     <node>console</node>
   </module>
 
-    <module>
-        <name>Teller</name>
-        <parameters>--</parameters>
-        <node>console</node>
-    </module>
+  <module>
+    <name>yarprobotinterface</name>
+    <parameters>--context voiceActivationDetection --from audioPlayer.ini</parameters>
+    <node>console</node>
+  </module>
 
-    <module>
-        <name>voiceActivationDetection</name>
-        <parameters>--</parameters>
-        <node>console</node>
-    </module>
+  <!-- playing the audio from the file original.wav to a port -->
+  <module>
+    <name>yarprobotinterface</name>
+    <parameters>--context voiceActivationDetection --from audioRecorderFromFile.ini</parameters>
+    <node>console</node>
+  </module>
+
+  <module>
+    <name>Teller</name>
+    <parameters>--</parameters>
+    <node>console</node>
+  </module>
+
+  <module>
+    <name>voiceActivationDetection</name>
+    <parameters>--</parameters>
+    <node>console</node>
+  </module>
 
 
 
-    <connection>
+  <connection>
     <from>/audioRecorderWrapper/audio:o</from>
     <to>/vad/audio:i</to>
     <protocol>tcp+recv.portmonitor+file.soundfilter_resample+type.dll+channel.0+frequency.16000</protocol>
   </connection>
 
 
-    <connection>
-        <from>/audioRecorderWrapper/audio:o</from>
-        <to>/audioPlayerWrapper/audio:i</to>
-        <protocol>tcp+recv.portmonitor+file.soundfilter_resample+type.dll+channel.0+frequency.16000</protocol>
-    </connection>
+  <connection>
+    <from>/audioRecorderWrapper/audio:o</from>
+    <to>/audioPlayerWrapper/audio:i</to>
+    <protocol>tcp+recv.portmonitor+file.soundfilter_resample+type.dll+channel.0+frequency.16000</protocol>
+  </connection>
 
-    <connection>
-        <from>/audioRecorderWrapper/audio:o</from>
-        <to>/original/audio:i</to>
-        <protocol>tcp+recv.portmonitor+file.soundfilter_resample+type.dll+channel.0+frequency.16000</protocol>
-    </connection>
+  <connection>
+    <from>/audioRecorderWrapper/audio:o</from>
+    <to>/original/audio:i</to>
+    <protocol>tcp+recv.portmonitor+file.soundfilter_resample+type.dll+channel.0+frequency.16000</protocol>
+  </connection>
 
   <connection>
     <from>/vad/audioFiltered:o</from>
@@ -79,34 +80,34 @@
   </connection>
 
 
-    <connection>
-        <from>/vad/sync_rpc:o</from>
-        <to>/HeadSynchronizer/vad/sync:i</to>
-        <protocol>fast_tcp</protocol>
-    </connection>
+  <connection>
+    <from>/vad/sync_rpc:o</from>
+    <to>/HeadSynchronizer/vad/sync:i</to>
+    <protocol>fast_tcp</protocol>
+  </connection>
 
-    <connection>
-        <from>/audioRecorderWrapper/status:o</from>
-        <to>/vad/microphone/status:i</to>
-        <protocol>fast_tcp</protocol>
-    </connection>
+  <connection>
+    <from>/audioRecorderWrapper/status:o</from>
+    <to>/vad/microphone/status:i</to>
+    <protocol>fast_tcp</protocol>
+  </connection>
 
-    <connection>
-        <from>/audioRecorderWrapper/audio:o</from>
-        <to>/vad/audio:i</to>
-        <protocol>tcp+recv.portmonitor+file.soundfilter_resample+type.dll+channel.0+frequency.16000</protocol>
-    </connection>
+  <connection>
+    <from>/audioRecorderWrapper/audio:o</from>
+    <to>/vad/audio:i</to>
+    <protocol>tcp+recv.portmonitor+file.soundfilter_resample+type.dll+channel.0+frequency.16000</protocol>
+  </connection>
 
-    <connection>
-        <from>/HeadSynchronizer/shared/rpc:o</from>
-        <to>/audioRecorderWrapper/rpc</to>
-        <protocol>fast_tcp</protocol>
-    </connection>
+  <connection>
+    <from>/HeadSynchronizer/shared/rpc:o</from>
+    <to>/audioRecorderWrapper/rpc</to>
+    <protocol>fast_tcp</protocol>
+  </connection>
 
-    <connection>
-        <from>/audioRecorderWrapper/status:o</from>
-        <to>/HeadSynchronizer/shared/microphone/status:o</to>
-        <protocol>fast_tcp</protocol>
-    </connection>
+  <connection>
+    <from>/audioRecorderWrapper/status:o</from>
+    <to>/HeadSynchronizer/shared/microphone/status:o</to>
+    <protocol>fast_tcp</protocol>
+  </connection>
 
 </application>

--- a/app/voiceActivationDetection/scripts/voiceActivationDetection.xml
+++ b/app/voiceActivationDetection/scripts/voiceActivationDetection.xml
@@ -6,18 +6,18 @@
 
   <module>
     <name>yarprobotinterface</name>
-    <parameters>--context voiceActivationDetection --from audioRecorder.ini</parameters>
+    <parameters>--context vadModule --from audioRecorder.ini</parameters>
     <node>r1-torso</node>
   </module>
 
   <module>
     <name>yarprobotinterface</name>
-    <parameters>--context voiceActivationDetection --from audioPlayer.ini</parameters>
+    <parameters>--context vadModule --from audioPlayer.ini</parameters>
     <node>r1-face</node>
   </module>
 
   <module>
-    <name>voiceActivationDetection</name>
+    <name>vadModule</name>
     <parameters></parameters>
     <environment>YARP_LOG_PROCESS_LABEL=VAD</environment>
     <node>r1-torso</node>

--- a/app/voiceActivationDetection/scripts/voiceActivationDetection.xml
+++ b/app/voiceActivationDetection/scripts/voiceActivationDetection.xml
@@ -5,16 +5,14 @@
   </dependencies>
 
   <module>
-    <name>yarpdev</name>
-    <parameters>--device AudioRecorderWrapper --subdevice portaudioRecorder --min_samples_over_network 8820 --max_samples_over_network 8820 --AUDIO_BASE::rate 44100 --AUDIO_BASE::samples 17640 --AUDIO_BASE::channels 1   </parameters>
-    <environment>YARP_LOG_PROCESS_LABEL=Audio_Recorder</environment>
+    <name>yarprobotinterface</name>
+    <parameters>--context voiceActivationDetection --from audioRecorder.ini</parameters>
     <node>r1-torso</node>
   </module>
 
   <module>
-    <name>yarpdev</name>
-    <parameters>--device AudioPlayerWrapper --subdevice portaudioPlayer --start --playback_network_buffer_size 0.1  --AUDIO_BASE::samples 1323000   </parameters>
-    <environment>YARP_LOG_PROCESS_LABEL=AudioPlayer</environment>
+    <name>yarprobotinterface</name>
+    <parameters>--context voiceActivationDetection --from audioPlayer.ini</parameters>
     <node>r1-face</node>
   </module>
 

--- a/app/voiceActivationDetection/scripts/voiceActivationDetection.xml
+++ b/app/voiceActivationDetection/scripts/voiceActivationDetection.xml
@@ -17,7 +17,7 @@
   </module>
 
   <module>
-    <name>vadModule</name>
+    <name>voiceActivationDetection</name>
     <parameters></parameters>
     <environment>YARP_LOG_PROCESS_LABEL=VAD</environment>
     <node>r1-torso</node>

--- a/app/voiceActivationDetection/scripts/voiceActivationDetection_faceTempFix.xml
+++ b/app/voiceActivationDetection/scripts/voiceActivationDetection_faceTempFix.xml
@@ -1,0 +1,50 @@
+<application>
+  <name>vad_faceTempFix</name>
+
+  <dependencies>
+  </dependencies>
+
+  <module>
+    <name>yarprobotinterface</name>
+    <parameters>--context vadModule --from audioRecorder.ini</parameters>
+    <node>r1-torso</node>
+  </module>
+
+  <module>
+    <name>yarpdev</name>
+    <parameters>--device AudioPlayerWrapper --subdevice portaudioPlayer --start --playback_network_buffer_size 0.1  --AUDIO_BASE::samples 1323000</parameters>
+    <node>r1-face</node>
+  </module>
+
+  <module>
+    <name>voiceActivationDetection</name>
+    <parameters></parameters>
+    <environment>YARP_LOG_PROCESS_LABEL=VAD</environment>
+    <node>r1-torso</node>
+  </module>
+
+  <connection>
+    <from>/audioRecorderWrapper/audio:o</from>
+    <to>/faceExpressionImage/earsAudioData:i</to>
+    <protocol>fast_tcp+recv.portmonitor+file.soundfilter_resample+type.dll+channel.0+frequency.16000</protocol>
+  </connection>
+
+  <connection>
+    <from>/audioRecorderWrapper/audio:o</from>
+    <to>/vad/audio:i</to>
+    <protocol>fast_tcp+recv.portmonitor+file.soundfilter_resample+type.dll+channel.0+frequency.16000</protocol>
+  </connection>
+
+    <connection>
+    <from>/audioRecorderWrapper/status:o</from>
+    <to>/vad/microphone/status:i </to>
+    <protocol>fast_tcp</protocol>
+  </connection>
+
+  <connection>
+    <from>/vad/audio:o</from>
+    <to>/googleSpeech/sound:i</to>
+    <protocol>fast_tcp</protocol>
+  </connection>
+
+</application>

--- a/app/voiceActivationDetection/scripts/voiceActivationDetection_sim.xml
+++ b/app/voiceActivationDetection/scripts/voiceActivationDetection_sim.xml
@@ -6,18 +6,18 @@
 
   <module>
     <name>yarprobotinterface</name>
-    <parameters>--context voiceActivationDetection --from audioRecorder.ini</parameters>
+    <parameters>--context vadModule --from audioRecorder.ini</parameters>
     <node>consoleOut</node>
   </module>
 
   <module>
     <name>yarprobotinterface</name>
-    <parameters>--context voiceActivationDetection --from audioPlayer.ini</parameters>
+    <parameters>--context vadModule --from audioPlayer.ini</parameters>
     <node>consoleOut</node>
   </module>
 
   <module>
-    <name>voiceActivationDetection</name>
+    <name>vadModule</name>
     <parameters></parameters>
     <environment>YARP_LOG_PROCESS_LABEL=VAD</environment>
     <node>console1</node>

--- a/app/voiceActivationDetection/scripts/voiceActivationDetection_sim.xml
+++ b/app/voiceActivationDetection/scripts/voiceActivationDetection_sim.xml
@@ -17,7 +17,7 @@
   </module>
 
   <module>
-    <name>vadModule</name>
+    <name>voiceActivationDetection</name>
     <parameters></parameters>
     <environment>YARP_LOG_PROCESS_LABEL=VAD</environment>
     <node>console1</node>

--- a/app/voiceActivationDetection/scripts/voiceActivationDetection_sim.xml
+++ b/app/voiceActivationDetection/scripts/voiceActivationDetection_sim.xml
@@ -5,16 +5,14 @@
   </dependencies>
 
   <module>
-    <name>yarpdev</name>
-    <parameters>--device AudioRecorderWrapper --subdevice portaudioRecorder --min_samples_over_network 8820 --max_samples_over_network 8820 --AUDIO_BASE::rate 44100 --AUDIO_BASE::samples 17640 --AUDIO_BASE::channels 1   </parameters>
-    <environment>YARP_LOG_PROCESS_LABEL=Audio_Recorder</environment>
+    <name>yarprobotinterface</name>
+    <parameters>--context voiceActivationDetection --from audioRecorder.ini</parameters>
     <node>consoleOut</node>
   </module>
 
   <module>
-    <name>yarpdev</name>
-    <parameters>--device AudioPlayerWrapper --subdevice portaudioPlayer --start --playback_network_buffer_size 0.1  --AUDIO_BASE::samples 1323000   </parameters>
-    <environment>YARP_LOG_PROCESS_LABEL=AudioPlayer</environment>
+    <name>yarprobotinterface</name>
+    <parameters>--context voiceActivationDetection --from audioPlayer.ini</parameters>
     <node>consoleOut</node>
   </module>
 


### PR DESCRIPTION
Now in the the xml files for the `yarpmanager` applications all the `yarpdev` calls have been replaced with `yarprobotinterface`. The needed `xml` configuration files have been added to the repo.