### PR TITLE
Ros2 isolation and Openpose dockerfile temp fix

### DIFF
--- a/docker_stuff/docker_mng_vars.sh
+++ b/docker_stuff/docker_mng_vars.sh
@@ -8,3 +8,4 @@ STABLE_SUFFIX="stable"
 REPO_DEF="elandini84/r1images"
 JUNCTION="_"
 REPO_SEP=":"
+ROS_DOMAIN_ID=37 #The number should be between 0-101 (https://docs.ros.org/en/iron/Concepts/Intermediate/About-Domain-ID.html#overview)

--- a/docker_stuff/docker_openPose/Dockerfile
+++ b/docker_stuff/docker_openPose/Dockerfile
@@ -53,7 +53,11 @@ RUN git clone https://github.com/CMU-Perceptual-Computing-Lab/openpose && \
 RUN cd $user1_home/openpose && \
     mkdir build && \
     cd ./build && \
-    cmake .. -DDOWNLOAD_HAND_MODEL=OFF -DUSE_CUDNN=OFF && \
+    # Right now the following does not work. 
+    # https://github.com/CMU-Perceptual-Computing-Lab/openpose/issues/2233
+    # You have to download the weights manually
+    # cmake .. -DDOWNLOAD_HAND_MODEL=OFF -DUSE_CUDNN=OFF && \
+    cmake .. -DDOWNLOAD_HAND_MODEL=OFF -DDOWNLOAD_BODY_25_MODEL=OFF -DDOWNLOAD_FACE_MODEL=OFF -DUSE_CUDNN=OFF && \
     make -j11
 ENV openpose_ROOT=$user1_home/openpose
 

--- a/docker_stuff/docker_sim2/manage-docker.sh
+++ b/docker_stuff/docker_sim2/manage-docker.sh
@@ -156,9 +156,9 @@ if [[ $GONNA_BUILD == "true" ]]; then
 else
     sudo xhost +
     if [[ $RUN_WITH_GPU == "true" ]]; then
-        sudo docker run --rm -it --privileged --network host --pid host -e NVIDIA_DRIVER_CAPABILITIES=all -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -e QT_X11_NO_MITSHM=1 --gpus all $COMPLETE_IMAGE_NAME
+        sudo docker run --rm -it --privileged --network host --pid host -e NVIDIA_DRIVER_CAPABILITIES=all -e DISPLAY -e ROS_DOMAIN_ID=${ROS_DOMAIN_ID} -v /tmp/.X11-unix:/tmp/.X11-unix -e QT_X11_NO_MITSHM=1 --gpus all $COMPLETE_IMAGE_NAME
     elif [[ $RUN_WITH_GPU == "false" && $IMAGE == $UBUNTU_DEF ]]; then
-        sudo docker run --rm -it --privileged --network host --pid host -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -e QT_X11_NO_MITSHM=1 $COMPLETE_IMAGE_NAME
+        sudo docker run --rm -it --privileged --network host --pid host -e DISPLAY -e ROS_DOMAIN_ID=${ROS_DOMAIN_ID} -v /tmp/.X11-unix:/tmp/.X11-unix -e QT_X11_NO_MITSHM=1 $COMPLETE_IMAGE_NAME
     else
         echo "ERROR: You cannot run a nVidia based image without gpu support"
     fi


### PR DESCRIPTION
While running the sim docker I noticed that we are multicasting on the whole network.
I am proposing to modify the ROS_DOMAIN_ID to isolate the network (currently implicitly set to 0).

For more reference see
https://docs.ros.org/en/iron/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#the-ros-domain-id-variable 
https://docs.ros.org/en/iron/Concepts/Intermediate/About-Domain-ID.html#overview

Openpose currently cannot be built if one tries to download the models during cmake. Thus the behaviour needs to be deactivated and one has to manually load the weights.

See this issue: https://github.com/CMU-Perceptual-Computing-Lab/openpose/issues/2233