### PR TITLE
Ros_launch.sh and example

### DIFF
--- a/app/navigation2/scripts/Navigation_ROS2_R1_SIM.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1_SIM.xml
@@ -6,6 +6,13 @@
    <!-- modules -->
 
    <module>
+      <name>ros2_launch.sh</name>
+      <parameters>/usr/local/src/hsp/tour-guide-robot/app/navigation2/launch/robot_state_publisher.launch.py use_sim_time:=true</parameters>
+      <workdir>/home/user1/tour-guide-robot/app/navigation2/scripts/</workdir>
+      <node>console</node>
+   </module>
+
+   <module>
       <name>ros2</name>
       <parameters>launch robot_state_publisher.launch.py use_sim_time:=true</parameters>
       <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>

--- a/app/navigation2/scripts/ros2_launch.sh
+++ b/app/navigation2/scripts/ros2_launch.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This scripts wraps ros2 launch handling the SIGTERM signal - currently bugged in ros2 (https://github.com/ros2/launch/issues/666)
+# In particular, the user can substitute the ros2 launch command in yarpmanager with this script.
+# The syntax is the same but the full path to the launch_file is needed.
+# Stopping the script via yarpmanager will correctly stop the nodes. Killing the script will leave the nodes dangling.
+
+
+_term() {
+	echo "Got SIGTERM"
+	kill -2 -${group}
+}
+
+if [ "$#" -lt 2 ]
+then
+	echo "Usage ros2_launch.sh <package> <launch_file> <args>"
+	exit -1
+fi
+
+trap _term SIGTERM
+
+setsid ros2 launch $@ --noninteractive &
+
+group=$!
+echo "Group pid: $group"
+child=$!
+wait "$child"


### PR DESCRIPTION
Proof of concept for a workaround that allows the user to run ros2 launch files from yarpmanager and correctly stop the nodes managed by the launch file.

Currently `ros2 launch` is not stopped correctly by a SIGTERM signal (https://github.com/ros2/launch/issues/666) which leaves the underline nodes dangling. Unfortunately for us this is exactly what happens under the hood when we stop from yarpmanager.

Of the many possible workaround to fix this behaviour I propose this one since it allows us to modify the applications that need it once for all and we don't have to worry about it at runtime nor we risk introducing regressions in yarprun.

I am also leaving an example attached. I am open to discuss if it would be worth to transform this in a piece of software more structured than this - admittedly rough - bash script
