### PR TITLE
Refactor: App xml and env variables

### DIFF
--- a/app/navigation2/conf/joystick_cer_linux_high_speed_stratus.ini
+++ b/app/navigation2/conf/joystick_cer_linux_high_speed_stratus.ini
@@ -29,14 +29,14 @@ Ax8 cartesian_xyz   7
 
 //Important:  you can execute only one-word commands or scripts
 [BUTTONS_EXECUTE]
-button0  /home/user1/tour-guide-robot/app/navigation2/scripts/cer_motors_run.sh
-button1  /home/user1/tour-guide-robot/app/navigation2/scripts/cer_motors_idle.sh
-button3  /home/user1/tour-guide-robot/app/navigation2/scripts/cer_speed1.sh
-button4  /home/user1/tour-guide-robot/app/navigation2/scripts/cer_speed2.sh
-button6  /usr/local/src/robot/tour-guide-robot/app/navigation/scripts/demo_speech.sh
-button7  /home/user1/tour-guide-robot/app/navigation2/scripts/cer_speed3.sh //Only CER01 has a third speed
-button13  /home/user1/tour-guide-robot/app/headSynchronizer/scripts/micOff.sh
-button14  /home/user1/tour-guide-robot/app/headSynchronizer/scripts/micOn.sh
+button0  cer_motors_run.sh
+button1  cer_motors_idle.sh
+button3  cer_speed1.sh
+button4  cer_speed2.sh
+button6  demo_speech.sh
+button7  cer_speed3.sh //Only CER01 has a third speed
+button13  micOff.sh
+button14  micOn.sh
 
 // **** Buttons ****
 // button0 A

--- a/app/navigation2/launch/map_server.launch.py
+++ b/app/navigation2/launch/map_server.launch.py
@@ -8,6 +8,7 @@ from launch_ros.actions import Node
 def generate_launch_description():
 
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
+    tourFolder = os.environ.get('TOUR_GUIDE_ROBOT_SOURCE_DIR')
 
     return LaunchDescription([
         DeclareLaunchArgument(
@@ -18,7 +19,7 @@ def generate_launch_description():
             package='nav2_map_server',
             executable='map_server',
             parameters=[
-                {'yaml_filename': '/home/user1/tour-guide-robot/app/maps/gam_sim_real.yaml'}]
+                {'yaml_filename': tourFolder+'/app/maps/gam_sim_real.yaml'}]
         ),
         Node(
             package='nav2_lifecycle_manager',

--- a/app/navigation2/launch/robot_state_publisher.launch.py
+++ b/app/navigation2/launch/robot_state_publisher.launch.py
@@ -7,8 +7,9 @@ from launch_ros.actions import Node
 def generate_launch_description():
 
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
+    cersimFolder = os.environ.get('CER_SIM_ROOT_DIR')
 
-    urdf = os.path.abspath("/home/user1/robotology/cer-sim/R1SN00x_urdf/R1SN003/cer.urdf")
+    urdf = os.path.abspath(cersimFolder+"/R1SN00x_urdf/R1SN003/cer.urdf")
     with open(urdf, 'r') as infp:
         robot_desc = infp.read()
 

--- a/app/navigation2/scripts/Navigation_ROS2_R1SN001.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1SN001.xml
@@ -34,7 +34,7 @@
    <module>
       <name>ros2</name>
       <parameters>launch robot_state_publisher.launch.py</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>r1-base</node>
    </module>
 
@@ -53,7 +53,7 @@
    <module>
       <name>./set_navigation_position_001.sh</name>
       <parameters></parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/scripts/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/scripts/</workdir>
       <node>console</node>
    </module>
 
@@ -66,7 +66,7 @@
    <module>
       <name>ros2</name>
       <parameters>launch amcl.launch.py</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>r1-base</node>
    </module>
 
@@ -79,7 +79,7 @@
    <module>
       <name>ros2</name>
       <parameters>launch navigation.launch.py</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>console</node>
    </module>
 
@@ -104,7 +104,7 @@
    <module>
       <name>rviz2</name>
       <parameters>-d r1_visualizer.rviz</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/conf/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/conf/</workdir>
       <node>console</node>
    </module>
 

--- a/app/navigation2/scripts/Navigation_ROS2_R1SN001.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1SN001.xml
@@ -8,7 +8,7 @@
    <module>
       <name>yarprobotinterface</name>
       <parameters></parameters>
-      <workdir>/home/user1/robotology/robots-configuration/R1SN001</workdir>
+      <workdir>$ENV{ROBOT_CODE}/robots-configuration/R1SN001</workdir>
       <node>r1-base</node>
    </module>
 

--- a/app/navigation2/scripts/Navigation_ROS2_R1SN003.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1SN003.xml
@@ -8,7 +8,7 @@
    <module>
       <name>yarprobotinterface</name>
       <parameters></parameters>
-      <workdir>/home/user1/robotology/robots-configuration/R1SN003/</workdir>
+      <workdir>$ENV{ROBOT_CODE}/robots-configuration/R1SN003/</workdir>
       <node>r1-base</node>
    </module>
 

--- a/app/navigation2/scripts/Navigation_ROS2_R1SN003.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1SN003.xml
@@ -92,7 +92,7 @@
    <module>
 
       <name>ros2</name>
-      <parameters>launch launch/costmap_filter_info.launch.py 'params_file:=$(env TOUR_GUIDE_ROBOT_SOURCE_DIR)/app/navigation2/conf/cris_new_area_fixed_keepout_params.yaml' 'mask:=$(env TOUR_GUIDE_ROBOT_SOURCE_DIR)/app/maps/cris_new_area_fixed_keepout_mask.yaml'</parameters>
+      <parameters>launch launch/costmap_filter_info.launch.py params_file:=$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/conf/cris_new_area_fixed_keepout_params.yaml mask:=$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/maps/cris_new_area_fixed_keepout_mask.yaml</parameters>
       <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/</workdir>
       <node>console</node>
    </module>

--- a/app/navigation2/scripts/Navigation_ROS2_R1SN003.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1SN003.xml
@@ -33,7 +33,7 @@
    <module>
       <name>ros2</name>
       <parameters>launch robot_state_publisher.launch.py</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>r1-base</node>
    </module>
 
@@ -59,7 +59,7 @@
    <module>
       <name>./set_navigation_position.sh</name>
       <parameters></parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/scripts/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/scripts/</workdir>
       <node>console</node>
    </module>
 
@@ -72,7 +72,7 @@
    <module>
       <name>ros2</name>
       <parameters>launch amcl.launch.py</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>r1-base</node>
    </module>
 
@@ -85,15 +85,15 @@
    <module>
       <name>ros2</name>
       <parameters>launch navigation.launch.py</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>console</node>
    </module>
 
    <module>
 
       <name>ros2</name>
-      <parameters>launch launch/costmap_filter_info.launch.py params_file:=conf/cris_new_area_fixed_keepout_params.yaml mask:=/home/user1/tour-guide-robot/app/maps/cris_new_area_fixed_keepout_mask.yaml</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/</workdir>
+      <parameters>launch launch/costmap_filter_info.launch.py 'params_file:=$(env TOUR_GUIDE_ROBOT_SOURCE_DIR)/app/navigation2/conf/cris_new_area_fixed_keepout_params.yaml' 'mask:=$(env TOUR_GUIDE_ROBOT_SOURCE_DIR)/app/maps/cris_new_area_fixed_keepout_mask.yaml'</parameters>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/</workdir>
       <node>console</node>
    </module>
 
@@ -112,7 +112,7 @@
    <module>
       <name>rviz2</name>
       <parameters>-d r1_visualizer.rviz</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/conf/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/conf/</workdir>
       <node>console</node>
    </module>
 

--- a/app/navigation2/scripts/Navigation_ROS2_R1SN003_dummy.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1SN003_dummy.xml
@@ -84,7 +84,7 @@
 
    <module>
       <name>ros2</name>
-      <parameters>launch navigation.launch.py 'params_file:=$(env TOUR_GUIDE_ROBOT_SOURCE_DIR)/app/navigation2/conf/nav2_unknown_params.yaml'</parameters>
+      <parameters>launch navigation.launch.py params_file:=$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/conf/nav2_unknown_params.yaml</parameters>
       <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>console</node>
    </module>

--- a/app/navigation2/scripts/Navigation_ROS2_R1SN003_dummy.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1SN003_dummy.xml
@@ -33,7 +33,7 @@
    <module>
       <name>ros2</name>
       <parameters>launch robot_state_publisher.launch.py</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>r1-base</node>
    </module>
 
@@ -59,7 +59,7 @@
    <module>
       <name>./set_navigation_position.sh</name>
       <parameters></parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/scripts/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/scripts/</workdir>
       <node>console</node>
    </module>
 
@@ -72,7 +72,7 @@
    <module>
       <name>ros2</name>
       <parameters>launch amcl.launch.py</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>r1-base</node>
    </module>
 
@@ -84,8 +84,8 @@
 
    <module>
       <name>ros2</name>
-      <parameters>launch navigation.launch.py params_file:=/home/user1/tour-guide-robot/app/navigation2/conf/nav2_unknown_params.yaml</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <parameters>launch navigation.launch.py 'params_file:=$(env TOUR_GUIDE_ROBOT_SOURCE_DIR)/app/navigation2/conf/nav2_unknown_params.yaml'</parameters>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>console</node>
    </module>
 
@@ -104,7 +104,7 @@
    <module>
       <name>rviz2</name>
       <parameters>-d r1_visualizer.rviz</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/conf/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/conf/</workdir>
       <node>console</node>
    </module>
 

--- a/app/navigation2/scripts/Navigation_ROS2_R1SN003_dummy.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1SN003_dummy.xml
@@ -8,7 +8,7 @@
    <module>
       <name>yarprobotinterface</name>
       <parameters></parameters>
-      <workdir>/home/user1/robotology/robots-configuration/R1SN003/</workdir>
+      <workdir>$ENV{ROBOT_CODE}/robots-configuration/R1SN003/</workdir>
       <node>r1-base</node>
    </module>
 

--- a/app/navigation2/scripts/Navigation_ROS2_R1_SIM.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1_SIM.xml
@@ -72,7 +72,7 @@
 
    <module>
       <name>ros2</name>
-      <parameters>launch costmap_filter_info.launch.py 'params_file:=$(env TOUR_GUIDE_ROBOT_SOURCE_DIR)/app/navigation2/conf/gam_sim_real_keepout_params.yaml' 'mask:=$(env TOUR_GUIDE_ROBOT_SOURCE_DIR)/app/maps/gam_sim_real_keepout_mask.yaml' use_sim_time:=true</parameters>
+      <parameters>launch costmap_filter_info.launch.py params_file:=$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/conf/gam_sim_real_keepout_params.yaml mask:=$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/maps/gam_sim_real_keepout_mask.yaml use_sim_time:=true</parameters>
       <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>console</node>
    </module>

--- a/app/navigation2/scripts/Navigation_ROS2_R1_SIM.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1_SIM.xml
@@ -8,14 +8,14 @@
    <module>
       <name>ros2_launch.sh</name>
       <parameters>/usr/local/src/hsp/tour-guide-robot/app/navigation2/launch/robot_state_publisher.launch.py use_sim_time:=true</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/scripts/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/scripts/</workdir>
       <node>console</node>
    </module>
 
    <module>
       <name>ros2</name>
       <parameters>launch robot_state_publisher.launch.py use_sim_time:=true</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>console</node>
    </module>
 
@@ -28,7 +28,7 @@
    <module>
       <name>./set_navigation_position_sim.sh</name>
       <parameters></parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/scripts/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/scripts/</workdir>
       <node>console</node>
    </module>
 
@@ -53,7 +53,7 @@
    <module>
       <name>ros2</name>
       <parameters>launch amcl.launch.py use_sim_time:=true</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>console</node>
    </module>
 
@@ -66,14 +66,14 @@
    <module>
       <name>ros2</name>
       <parameters>launch navigation.launch.py use_sim_time:=true</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>console</node>
    </module>
 
    <module>
       <name>ros2</name>
-      <parameters>launch costmap_filter_info.launch.py params_file:=../conf/gam_sim_real_keepout_params.yaml mask:=../../maps/gam_sim_real_keepout_mask.yaml use_sim_time:=true</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <parameters>launch costmap_filter_info.launch.py 'params_file:=$(env TOUR_GUIDE_ROBOT_SOURCE_DIR)/app/navigation2/conf/gam_sim_real_keepout_params.yaml' 'mask:=$(env TOUR_GUIDE_ROBOT_SOURCE_DIR)/app/maps/gam_sim_real_keepout_mask.yaml' use_sim_time:=true</parameters>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>console</node>
    </module>
 
@@ -92,7 +92,7 @@
    <module>
       <name>rviz2</name>
       <parameters>-d r1_visualizer.rviz --ros-args --remap use_sim_time:=true</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/conf/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/conf/</workdir>
       <node>console</node>
    </module>
 

--- a/app/navigation2/scripts/Navigation_ROS2_R1_SIM_dummy.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1_SIM_dummy.xml
@@ -8,7 +8,7 @@
    <module>
       <name>ros2</name>
       <parameters>launch robot_state_publisher.launch.py use_sim_time:=true</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>console</node>
    </module>
 
@@ -21,7 +21,7 @@
    <module>
       <name>./set_navigation_position_sim.sh</name>
       <parameters></parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/scripts/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/scripts/</workdir>
       <node>console</node>
    </module>
 
@@ -46,7 +46,7 @@
    <module>
       <name>ros2</name>
       <parameters>launch amcl.launch.py use_sim_time:=true</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>console</node>
    </module>
 
@@ -58,8 +58,8 @@
 
    <module>
       <name>ros2</name>
-      <parameters>launch navigation.launch.py use_sim_time:=true params_file:=/home/user1/tour-guide-robot/app/navigation2/conf/nav2_unknown_params.yaml</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/launch/</workdir>
+      <parameters>launch navigation.launch.py use_sim_time:=true 'params_file:=$(env TOUR_GUIDE_ROBOT_SOURCE_DIR)/app/navigation2/conf/nav2_unknown_params.yaml'</parameters>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>console</node>
    </module>
 
@@ -78,7 +78,7 @@
    <module>
       <name>rviz2</name>
       <parameters>-d r1_visualizer.rviz --ros-args --remap use_sim_time:=true</parameters>
-      <workdir>/home/user1/tour-guide-robot/app/navigation2/conf/</workdir>
+      <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/conf/</workdir>
       <node>console</node>
    </module>
 

--- a/app/navigation2/scripts/Navigation_ROS2_R1_SIM_dummy.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1_SIM_dummy.xml
@@ -58,7 +58,7 @@
 
    <module>
       <name>ros2</name>
-      <parameters>launch navigation.launch.py use_sim_time:=true 'params_file:=$(env TOUR_GUIDE_ROBOT_SOURCE_DIR)/app/navigation2/conf/nav2_unknown_params.yaml'</parameters>
+      <parameters>launch navigation.launch.py use_sim_time:=true params_file:=$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/conf/nav2_unknown_params.yaml</parameters>
       <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>console</node>
    </module>

--- a/app/navigation2/scripts/evaluate_ip.sh
+++ b/app/navigation2/scripts/evaluate_ip.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 current_ip=$(ifconfig | grep 192.168.100. | awk '{print $2}')
 echo $current_ip
-if [ $current_ip = "192.168.100.10" ]; 
+if [ $current_ip = "192.168.100.10" ];
 then
   echo "base"
-  sed -i -e "s/REMOTEIP/192\.168\.100\.1/g" /home/user1/tour-guide-robot/app/navigation2/conf/cyclone_dds_settings.xml
+  sed -i -e "s/REMOTEIP/192\.168\.100\.1/g" ${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/conf/cyclone_dds_settings.xml
 else
   echo "different"
-  sed -i -e "s/REMOTEIP/192\.168\.100\.10/g" /home/user1/tour-guide-robot/app/navigation2/conf/cyclone_dds_settings.xml
+  sed -i -e "s/REMOTEIP/192\.168\.100\.10/g" ${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/conf/cyclone_dds_settings.xml
 fi
-sed -i -e "s/LOCALIP/$current_ip/g" /home/user1/tour-guide-robot/app/navigation2/conf/cyclone_dds_settings.xml
+sed -i -e "s/LOCALIP/$current_ip/g" ${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/conf/cyclone_dds_settings.xml
 

--- a/app/navigation2/scripts/start_sim.sh
+++ b/app/navigation2/scripts/start_sim.sh
@@ -1,6 +1,6 @@
 yarpserver &
 sleep 1;
-ros2 launch gazebo_ros gazebo.launch.py extra_gazebo_args:=-slibgazebo_yarp_clock.so world:=/home/user1/tour-guide-robot/app/maps/SIM_GAM/GAM.world &
+ros2 launch gazebo_ros gazebo.launch.py extra_gazebo_args:=-slibgazebo_yarp_clock.so world:=${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/maps/SIM_GAM/GAM.world &
 sleep 1;
 yarprun --server /console --log &
 sleep 1;

--- a/app/navigation2/scripts/start_sim_crowd_sim.sh
+++ b/app/navigation2/scripts/start_sim_crowd_sim.sh
@@ -1,6 +1,6 @@
 yarpserver &
 sleep 1;
-ros2 launch gazebo_ros gazebo.launch.py extra_gazebo_args:=-slibgazebo_yarp_clock.so world:=/home/user1/tour-guide-robot/app/maps/SIM_GAM/GAM_crowd_sim.world &
+ros2 launch gazebo_ros gazebo.launch.py extra_gazebo_args:=-slibgazebo_yarp_clock.so world:=${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/maps/SIM_GAM/GAM_crowd_sim.world &
 sleep 1;
 yarprun --server /console --log &
 sleep 1;

--- a/app/navigation2/scripts/start_sim_dummy.sh
+++ b/app/navigation2/scripts/start_sim_dummy.sh
@@ -1,6 +1,6 @@
 yarpserver &
 sleep 1;
-ros2 launch gazebo_ros gazebo.launch.py extra_gazebo_args:=-slibgazebo_yarp_clock.so world:=/home/user1/tour-guide-robot/app/maps/SIM_GAM/dummy.world &
+ros2 launch gazebo_ros gazebo.launch.py extra_gazebo_args:=-slibgazebo_yarp_clock.so world:=${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/maps/SIM_GAM/dummy.world &
 sleep 1;
 yarprun --server /console --log &
 sleep 1;

--- a/app/openPoseStuff/scripts/open_pose_app.xml
+++ b/app/openPoseStuff/scripts/open_pose_app.xml
@@ -13,7 +13,7 @@
 
 	<module>
 		<name>python3</name>
-		<parameters>/home/user1/robotology/iCubContrib/bin/multiface-mutualgaze-classifier.py --context mutual-gaze-classifier-demo --from classifier_conf.ini</parameters>
+		<parameters>$ENX{ROBOT_CODE}/iCubContrib/bin/multiface-mutualgaze-classifier.py --context mutual-gaze-classifier-demo --from classifier_conf.ini</parameters>
 		<node>console3</node>
 	</module>
 

--- a/docker_stuff/docker_openPose/Dockerfile
+++ b/docker_stuff/docker_openPose/Dockerfile
@@ -168,6 +168,7 @@ ENV LD_LIBRARY_PATH=$robotology_install_folder/yarp/build/lib/yarp/
 ENV YARP_COLORED_OUTPUT=1
 ENV QT_X11_NO_MITSHM=1
 ENV PYTHONPATH=$PYTHONPATH:/home/user1/robotology/yarp/bindings/build/lib/python3/
+ENV TOUR_GUIDE_ROBOT_SOURCE_DIR=/home/user1/tour-guide-robot
 ENV CYCLONEDDS_URI=/home/user1/tour-guide-robot/app/navigation2/conf/cyclone_dds_settings.xml
 
 # Manage yarp port

--- a/docker_stuff/docker_sim2/Dockerfile
+++ b/docker_stuff/docker_sim2/Dockerfile
@@ -206,8 +206,9 @@ RUN echo "PS1='\[\e]0;\u \w\a\]\[\033[01;32m\]\u\[\033[00m\] \[\033[01;34m\]\w\[
 RUN echo "source /opt/ros/$ros_distro/setup.bash" >> /home/user1/.bashrc
 RUN echo "source /home/user1/robotology/yarp-devices-ros2/ros2_interfaces_ws/install/local_setup.bash" >> /home/user1/.bashrc
 ENV TOUR_GUIDE_ROBOT_SOURCE_DIR=/home/user1/tour-guide-robot
-ENV PATH=$PATH:$YARP_DIR/bin:$navigation_DIR/bin:$CER_DIR/bin:$ICUB_DIR/bin:$ICUB_DIR:$robotology_install_folder/iCubContrib/bin:/home/user1/robotology/Groot/build:/home/user1/tour-guide-robot/build/bin:${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/scripts:${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/headSynchronizer/scripts
 ENV ROBOT_CODE=/home/user1/robotology
+ENV CER_SIM_ROOT_DIR=${ROBOT_CODE}/cer-sim
+ENV PATH=$PATH:$YARP_DIR/bin:$navigation_DIR/bin:$CER_DIR/bin:$ICUB_DIR/bin:$ICUB_DIR:$robotology_install_folder/iCubContrib/bin:/home/user1/robotology/Groot/build:/home/user1/tour-guide-robot/build/bin:${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/scripts:${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/headSynchronizer/scripts
 ENV DISPLAY=:1
 ENV YARP_DATA_DIRS=$YARP_DIR/share/yarp:$ICUB_DIR/share/iCub:$navigation_DIR/share/navigation:$user1_home/tour-guide-robot/build/share/tour-guide-robot:$CER_DIR/share/CER:$ICUBcontrib_DIR/share/ICUBcontrib:$robotology_install_folder/yarp-devices-ros2/build/share/yarp:$robotology_install_folder/yarp-devices-ros2/build/share/yarp-devices-ros2
 ENV LD_LIBRARY_PATH=$robotology_install_folder/yarp/build/lib/yarp/

--- a/docker_stuff/docker_sim2/Dockerfile
+++ b/docker_stuff/docker_sim2/Dockerfile
@@ -215,6 +215,7 @@ ENV YARP_COLORED_OUTPUT=1
 ENV QT_X11_NO_MITSHM=1
 ENV PYTHONPATH=$PYTHONPATH:/home/user1/robotology/yarp/bindings/build/lib/python3/
 ENV YARP_CLOCK=/clock
+ENV TOUR_GUIDE_ROBOT_SOURCE_DIR=/home/user1/tour-guide-robot
 #ENV CYCLONEDDS_URI=/home/user1/tour-guide-robot/app/navigation2/conf/cyclone_dds_settings.xml
 
 # Manage yarp port

--- a/docker_stuff/docker_sim2/Dockerfile
+++ b/docker_stuff/docker_sim2/Dockerfile
@@ -205,7 +205,9 @@ USER $robotology_install_user
 RUN echo "PS1='\[\e]0;\u \w\a\]\[\033[01;32m\]\u\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\] \$ '" >> /home/$robotology_install_user/.bashrc
 RUN echo "source /opt/ros/$ros_distro/setup.bash" >> /home/user1/.bashrc
 RUN echo "source /home/user1/robotology/yarp-devices-ros2/ros2_interfaces_ws/install/local_setup.bash" >> /home/user1/.bashrc
-ENV PATH=$PATH:$YARP_DIR/bin:$navigation_DIR/bin:$CER_DIR/bin:$ICUB_DIR/bin:$ICUB_DIR:$robotology_install_folder/iCubContrib/bin:/home/user1/robotology/Groot/build:/home/user1/tour-guide-robot/build/bin
+ENV TOUR_GUIDE_ROBOT_SOURCE_DIR=/home/user1/tour-guide-robot
+ENV PATH=$PATH:$YARP_DIR/bin:$navigation_DIR/bin:$CER_DIR/bin:$ICUB_DIR/bin:$ICUB_DIR:$robotology_install_folder/iCubContrib/bin:/home/user1/robotology/Groot/build:/home/user1/tour-guide-robot/build/bin:${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/scripts:${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/headSynchronizer/scripts
+ENV ROBOT_CODE=/home/user1/robotology
 ENV DISPLAY=:1
 ENV YARP_DATA_DIRS=$YARP_DIR/share/yarp:$ICUB_DIR/share/iCub:$navigation_DIR/share/navigation:$user1_home/tour-guide-robot/build/share/tour-guide-robot:$CER_DIR/share/CER:$ICUBcontrib_DIR/share/ICUBcontrib:$robotology_install_folder/yarp-devices-ros2/build/share/yarp:$robotology_install_folder/yarp-devices-ros2/build/share/yarp-devices-ros2
 ENV LD_LIBRARY_PATH=$robotology_install_folder/yarp/build/lib/yarp/
@@ -215,7 +217,6 @@ ENV YARP_COLORED_OUTPUT=1
 ENV QT_X11_NO_MITSHM=1
 ENV PYTHONPATH=$PYTHONPATH:/home/user1/robotology/yarp/bindings/build/lib/python3/
 ENV YARP_CLOCK=/clock
-ENV TOUR_GUIDE_ROBOT_SOURCE_DIR=/home/user1/tour-guide-robot
 #ENV CYCLONEDDS_URI=/home/user1/tour-guide-robot/app/navigation2/conf/cyclone_dds_settings.xml
 
 # Manage yarp port

--- a/docker_stuff/docker_tourCore2/Dockerfile
+++ b/docker_stuff/docker_tourCore2/Dockerfile
@@ -207,6 +207,7 @@ RUN echo "source /home/user1/robotology/yarp-devices-ros2/ros2_interfaces_ws/ins
 ENV TOUR_GUIDE_ROBOT_SOURCE_DIR=/home/user1/tour-guide-robot
 ENV PATH=$PATH:$YARP_DIR/bin:$navigation_DIR/bin:$CER_DIR/bin:$ICUB_DIR/bin:$ICUB_DIR:$robotology_install_folder/iCubContrib/bin:/home/user1/robotology/Groot/build:/home/user1/tour-guide-robot/build/bin:/home/user1/robotology/icub-main/build:${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/scripts:${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/headSynchronizer/scripts
 ENV ROBOT_CODE=/home/user1/robotology
+ENV CER_SIM_ROOT_DIR=${ROBOT_CODE}/cer-sim
 ENV DISPLAY=:1
 ENV YARP_DATA_DIRS=$YARP_DIR/share/yarp:$ICUB_DIR/share/iCub:$navigation_DIR/share/navigation:$user1_home/tour-guide-robot/build/share/tour-guide-robot:$CER_DIR/share/CER:$ICUBcontrib_DIR/share/ICUBcontrib:$robotology_install_folder/yarp-devices-ros2/build/share/yarp:$robotology_install_folder/yarp-devices-ros2/build/share/yarp-devices-ros2:$robotology_install_folder/yarp-device-rplidar/build/share/yarp:$ICUBcontrib_SHARE
 ENV LD_LIBRARY_PATH=$robotology_install_folder/yarp/build/lib/yarp/

--- a/docker_stuff/docker_tourCore2/Dockerfile
+++ b/docker_stuff/docker_tourCore2/Dockerfile
@@ -204,14 +204,15 @@ USER $robotology_install_user
 RUN echo "PS1='\[\e]0;\u \w\a\]\[\033[01;32m\]\u\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\] \$ '" >> /home/$robotology_install_user/.bashrc
 RUN echo "source /opt/ros/$ros_distro/setup.bash" >> /home/user1/.bashrc
 RUN echo "source /home/user1/robotology/yarp-devices-ros2/ros2_interfaces_ws/install/local_setup.bash" >> /home/user1/.bashrc
-ENV PATH=$PATH:$YARP_DIR/bin:$navigation_DIR/bin:$CER_DIR/bin:$ICUB_DIR/bin:$ICUB_DIR:$robotology_install_folder/iCubContrib/bin:/home/user1/robotology/Groot/build:/home/user1/tour-guide-robot/build/bin:/home/user1/robotology/icub-main/build
+ENV TOUR_GUIDE_ROBOT_SOURCE_DIR=/home/user1/tour-guide-robot
+ENV PATH=$PATH:$YARP_DIR/bin:$navigation_DIR/bin:$CER_DIR/bin:$ICUB_DIR/bin:$ICUB_DIR:$robotology_install_folder/iCubContrib/bin:/home/user1/robotology/Groot/build:/home/user1/tour-guide-robot/build/bin:/home/user1/robotology/icub-main/build:${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/scripts:${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/headSynchronizer/scripts
+ENV ROBOT_CODE=/home/user1/robotology
 ENV DISPLAY=:1
 ENV YARP_DATA_DIRS=$YARP_DIR/share/yarp:$ICUB_DIR/share/iCub:$navigation_DIR/share/navigation:$user1_home/tour-guide-robot/build/share/tour-guide-robot:$CER_DIR/share/CER:$ICUBcontrib_DIR/share/ICUBcontrib:$robotology_install_folder/yarp-devices-ros2/build/share/yarp:$robotology_install_folder/yarp-devices-ros2/build/share/yarp-devices-ros2:$robotology_install_folder/yarp-device-rplidar/build/share/yarp:$ICUBcontrib_SHARE
 ENV LD_LIBRARY_PATH=$robotology_install_folder/yarp/build/lib/yarp/
 ENV YARP_COLORED_OUTPUT=1
 ENV QT_X11_NO_MITSHM=1
 ENV PYTHONPATH=$PYTHONPATH:/home/user1/robotology/yarp/bindings/build/lib/python3/
-ENV TOUR_GUIDE_ROBOT_SOURCE_DIR=/home/user1/tour-guide-robot
 ENV CYCLONEDDS_URI=/home/user1/tour-guide-robot/app/navigation2/conf/cyclone_dds_settings.xml
 
 # Manage yarp port

--- a/docker_stuff/docker_tourCore2/Dockerfile
+++ b/docker_stuff/docker_tourCore2/Dockerfile
@@ -211,6 +211,7 @@ ENV LD_LIBRARY_PATH=$robotology_install_folder/yarp/build/lib/yarp/
 ENV YARP_COLORED_OUTPUT=1
 ENV QT_X11_NO_MITSHM=1
 ENV PYTHONPATH=$PYTHONPATH:/home/user1/robotology/yarp/bindings/build/lib/python3/
+ENV TOUR_GUIDE_ROBOT_SOURCE_DIR=/home/user1/tour-guide-robot
 ENV CYCLONEDDS_URI=/home/user1/tour-guide-robot/app/navigation2/conf/cyclone_dds_settings.xml
 
 # Manage yarp port


### PR DESCRIPTION
Made a considerable amount of changes in order to remove absolute paths from the `yarpmanager` `.xml` applications. This changes require setting some environmental variables to store the needed paths. With this solution now tour-guide-robot code can run outside its docker if needed.