### PR TITLE
Added laboratory_area and laboratory_path to Erzelli map

### DIFF
--- a/app/maps/locations.ini
+++ b/app/maps/locations.ini
@@ -64,5 +64,7 @@ office_library              r1_small_office     6.34 2.38 50.0
 office_desk                 r1_small_office     1.50 2.80 80.0
 office_sofa_area            r1_small_office     4.20 -1.45 -86.61
 Areas:
+laboratory_area                           erzelli6 4 -1.8 0.2 3.3 3.8 6.2 -1.8 1.4 -4.8
 Paths:
+laboratory_path                           (erzelli6 2.50 4.20 0.0) (erzelli6 2.00 -1.31 0.0)
 sim_gam_ex_path                           (gam_sim_real -0.32 -3.3 -45.0) (gam_sim_real -0.2 -7.2 30.0)


### PR DESCRIPTION
Adding the area and the path necessary to make the navigation workaround at Erzelli work.