### PR TITLE
New docker image6 for Qt6 based image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,9 +51,11 @@ jobs:
       run: |
        if [ ${{ github.event_name }} == 'schedule' ]; then
           echo "Building development tour core image"
+          sudo rm -rf /opt/hostedtoolcache
           sudo docker build --build-arg base_img=${{matrix.config.base_image}} --build-arg ros_distro=${{matrix.config.ros2_distro}} -t elandini84/r1images:tourCore2_${{matrix.config.base_image_label}}_${{matrix.config.ros2_distro}}_devel .
        elif [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
           echo "Building stable tour core image"
+          sudo rm -rf /opt/hostedtoolcache
           sudo docker build --build-arg base_img=${{matrix.config.base_image}} --build-arg ros_distro=${{matrix.config.ros2_distro}} -t elandini84/r1images:tourCore2_${{matrix.config.base_image_label}}_${{matrix.config.ros2_distro}}_stable .
        else
           echo "Failure!"
@@ -117,9 +119,11 @@ jobs:
       run: |
        if [ ${{ github.event_name }} == 'schedule' ]; then
           echo "Building development tour simulation image"
+          sudo rm -rf /opt/hostedtoolcache
           sudo docker build --build-arg base_img=${{matrix.config.base_image}} --build-arg ros_distro=${{matrix.config.ros2_distro}} -t elandini84/r1images:tourSim2_${{matrix.config.base_image_label}}_${{matrix.config.ros2_distro}}_devel .
        elif [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
           echo "Building stable tour simulation image"
+          sudo rm -rf /opt/hostedtoolcache
           sudo docker build --build-arg base_img=${{matrix.config.base_image}} --build-arg ros_distro=${{matrix.config.ros2_distro}} -t elandini84/r1images:tourSim2_${{matrix.config.base_image_label}}_${{matrix.config.ros2_distro}}_stable .
        else
           echo "Failure!"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,18 @@ jobs:
             base_image_label: "cuda.12.8.1-cudnn",
             work_dir: "docker_stuff/docker_tourCore/"
          }
+         - {
+            ros2_distro: "jazzy",
+            base_image: "ubuntu:24.04",
+            base_image_label: "ubuntu24.04",
+            work_dir: "docker_stuff/docker_tourCore/"
+         }
+         - {
+            ros2_distro: "jazzy",
+            base_image: "ste93/convince:ubuntu_24.04_qt_6.7.3",
+            base_image_label: "ubuntu_24.04_qt_6.7.3",
+            work_dir: "docker_stuff/docker_tourCore/"
+         }
     steps:
     - name: Info
       run: |
@@ -82,6 +94,12 @@ jobs:
             ros2_distro: "jazzy",
             base_image: "nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04",
             base_image_label: "cuda.12.8.1-cudnn",
+            work_dir: "docker_stuff/docker_sim/"
+         }
+         - {
+            ros2_distro: "jazzy",
+            base_image: "ste93/convince:ubuntu_24.04_qt_6.7.3",
+            base_image_label: "ubuntu_24.04_qt_6.7.3",
             work_dir: "docker_stuff/docker_sim/"
          }
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,8 @@ jobs:
          }
          - {
             ros2_distro: "jazzy",
-            base_image: "ste93/convince:ubuntu_24.04_qt_6.7.3",
-            base_image_label: "ubuntu_24.04_qt_6.7.3",
+            base_image: "ste93/convince:ubuntu_24.04_qt_6.8.3",
+            base_image_label: "ubuntu_24.04_qt_6.8.3",
             work_dir: "docker_stuff/docker_tourCore/"
          }
     steps:
@@ -94,8 +94,8 @@ jobs:
          }
          - {
             ros2_distro: "jazzy",
-            base_image: "ste93/convince:ubuntu_24.04_qt_6.7.3",
-            base_image_label: "ubuntu_24.04_qt_6.7.3",
+            base_image: "ste93/convince:ubuntu_24.04_qt_6.8.3",
+            base_image_label: "ubuntu_24.04_qt_6.8.3",
             work_dir: "docker_stuff/docker_sim/"
          }
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,12 +26,6 @@ jobs:
          }
          - {
             ros2_distro: "jazzy",
-            base_image: "ubuntu:24.04",
-            base_image_label: "ubuntu24.04",
-            work_dir: "docker_stuff/docker_tourCore/"
-         }
-         - {
-            ros2_distro: "jazzy",
             base_image: "ste93/convince:ubuntu_24.04_qt_6.7.3",
             base_image_label: "ubuntu_24.04_qt_6.7.3",
             work_dir: "docker_stuff/docker_tourCore/"

--- a/.github/workflows/secondary.yml
+++ b/.github/workflows/secondary.yml
@@ -37,9 +37,11 @@ jobs:
       run: |
        if [ ${{ github.event_name }} == 'schedule' ]; then
           echo "Building development talk image"
+          sudo rm -rf /opt/hostedtoolcache
           docker compose build r1-talk-${{ matrix.config.ubuntu_version }}-${{ matrix.config.gcpp_version }}-master
        elif [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
           echo "Building stable talk image"
+          sudo rm -rf /opt/hostedtoolcache
           docker compose build r1-talk-${{ matrix.config.ubuntu_version }}-${{ matrix.config.gcpp_version }}-master
        else
           echo "Failure!"
@@ -90,9 +92,11 @@ jobs:
       run: |
        if [ ${{ github.event_name }} == 'schedule' ]; then
           echo "Building development custom cuda image"
+          sudo rm -rf /opt/hostedtoolcache
           sudo docker build --build-arg base_img=${{matrix.config.base_image}}devel --build-arg cuda_version=${{matrix.config.cuda_version}} -t elandini84/r1images:tourCore2_${{matrix.config.base_image_label}}_${{matrix.config.cuda_version}}_devel .
        elif [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
           echo "Building stable custom cuda image"
+          sudo rm -rf /opt/hostedtoolcache
           sudo docker build --build-arg base_img=${{matrix.config.base_image}}stable --build-arg cuda_version=${{matrix.config.cuda_version}} -t elandini84/r1images:tourCore2_${{matrix.config.base_image_label}}_${{matrix.config.cuda_version}}_stable .
        else
           echo "Failure!"
@@ -142,9 +146,11 @@ jobs:
       run: |
        if [ ${{ github.event_name }} == 'schedule' ]; then
           echo "Building development custom cuda image"
+          sudo rm -rf /opt/hostedtoolcache
           sudo docker build --build-arg base_img=${{matrix.config.base_image}}devel --build-arg cuda_version=${{matrix.config.cuda_version}} -t elandini84/r1images:tourSim2_${{matrix.config.base_image_label}}_${{matrix.config.cuda_version}}_devel .
        elif [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
           echo "Building stable custom cuda image"
+          sudo rm -rf /opt/hostedtoolcache
           sudo docker build --build-arg base_img=${{matrix.config.base_image}}stable --build-arg cuda_version=${{matrix.config.cuda_version}} -t elandini84/r1images:tourSim2_${{matrix.config.base_image_label}}_${{matrix.config.cuda_version}}_stable .
        else
           echo "Failure!"

--- a/docker_stuff/docker_sim/Dockerfile
+++ b/docker_stuff/docker_sim/Dockerfile
@@ -73,9 +73,6 @@ RUN mkdir Downloads && cd Downloads &&\
     sudo mv swig_4_2_1_ubuntu_24_04_install/bin/* /usr/bin && \
     sudo mv swig_4_2_1_ubuntu_24_04_install/share/swig /usr/share
 
-#gazebo models
-RUN mkdir -p $user1_home/.gazebo && git clone https://github.com/osrf/gazebo_models $user1_home/.gazebo/models
-
 # Build ycm
 USER ${robotology_install_user}
 WORKDIR ${robotology_install_folder}
@@ -251,8 +248,6 @@ ENV CER_SIM_ROOT_DIR=${ROBOT_CODE}/cer-sim
 ENV PATH=$PATH:$YARP_DIR/bin:$navigation_DIR/bin:$CER_DIR/bin:$ICUB_DIR/bin:$ICUB_DIR:${robotology_install_folder}/iCubContrib/bin:${robotology_install_folder}/Groot/build:${robotology_install_folder}/tour-guide-robot/build/bin:${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/scripts:${TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/headSynchronizer/scripts
 ENV DISPLAY=:1
 ENV LD_LIBRARY_PATH=${robotology_install_folder}/yarp/build/lib/yarp/
-ENV GAZEBO_PLUGIN_PATH=$GazeboYARPPlugins_DIR/lib
-ENV GAZEBO_MODEL_PATH=${robotology_install_folder}/cer-sim/gazebo/
 ENV YARP_COLORED_OUTPUT=1
 ENV QT_X11_NO_MITSHM=1
 ENV PYTHONPATH=$PYTHONPATH:${robotology_install_folder}/yarp/bindings/build/lib/python3/


### PR DESCRIPTION
Added a new config to the main.yml CI matrix to build tourCore and sim dockers based also on the image `ste93/convince:ubuntu_24.04_qt_6.8.3`