### PR TITLE
Added robot state publisher for new r1

### DIFF
--- a/app/navigation2/launch/robot_state_publisher_R1SN003.launch.py
+++ b/app/navigation2/launch/robot_state_publisher_R1SN003.launch.py
@@ -1,0 +1,29 @@
+import os
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+def generate_launch_description():
+
+    use_sim_time = LaunchConfiguration('use_sim_time', default='false')
+    r1_models_folder = os.environ.get('R1_MODELS_ROOT_DIR')
+
+    urdf = os.path.join(r1_models_folder,'urdf','R1Mk3','robots','R1SN003','model.urdf')
+    urdf = os.path.abspath(urdf)
+    with open(urdf, 'r') as infp:
+        robot_desc = infp.read()
+
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            'use_sim_time',
+            default_value='false',
+            description='Use simulation (Gazebo) clock if true'),
+        Node(
+            package='robot_state_publisher',
+            executable='robot_state_publisher',
+            name='robot_state_publisher',
+            output='screen',
+            parameters=[{'use_sim_time': use_sim_time, 'robot_description': robot_desc}],
+            arguments=[urdf])
+    ])

--- a/app/navigation2/scripts/Navigation_ROS2_R1SN003.xml
+++ b/app/navigation2/scripts/Navigation_ROS2_R1SN003.xml
@@ -32,7 +32,7 @@
 
    <module>
       <name>ros2_launch.sh</name>
-      <parameters>robot_state_publisher.launch.py</parameters>
+      <parameters>robot_state_publisher_R1SN003.launch.py</parameters>
       <workdir>$ENV{TOUR_GUIDE_ROBOT_SOURCE_DIR}/app/navigation2/launch/</workdir>
       <node>r1-base</node>
    </module>


### PR DESCRIPTION
This PR assumes that the r1_models dir is already installed on the r1-base and that the R1_MODELS_ROOT_DIR env variable is set. This has been already covered on the real robot.

### Added
robot_state_publisher.launch.py file pointing to the new urdf

### Modified
Changed robot state publisher ros2 launch in nav_ros2_r1sn003.xml