### PR TITLE
Fix: ears drawing on R1 face

### DIFF
--- a/app/demo/scripts/speechPipeline_demo_robot_valley_sim.xml
+++ b/app/demo/scripts/speechPipeline_demo_robot_valley_sim.xml
@@ -151,6 +151,12 @@
   </connection>
 
   <connection>
+    <from>/audioRecorder_nws/audio:o</from>
+    <to>/faceExpressionImage/earsAudioData:i</to>
+    <protocol>fast_tcp</protocol>
+  </connection>
+
+  <connection>
     <from>/wake/notification:o</from>
     <to>/wake_notification:i</to>
     <protocol>fast_tcp</protocol>

--- a/app/speechPipeline/scripts/speechPipeline_azure_conversation.xml
+++ b/app/speechPipeline/scripts/speechPipeline_azure_conversation.xml
@@ -116,4 +116,10 @@
     <protocol>fast_tcp</protocol>
   </connection>
 
+  <connection>
+    <from>/audioRecorder_nws/audio:o</from>
+    <to>/faceExpressionImage/earsAudioData:i</to>
+    <protocol>tcp+recv.portmonitor+file.soundfilter_resample+type.dll+channel.0+frequency.16000</protocol>
+  </connection>
+
 </application>

--- a/aux_modules/faceExpression/earsThread.cpp
+++ b/aux_modules/faceExpression/earsThread.cpp
@@ -91,12 +91,13 @@ void EarsThread::run()
 
     float percentage = 0.5;
 
-    yWarning("Check mic");
     yarp::sig::AudioRecorderStatus *rec_status = m_audioStatusPort.read(false);
     if (rec_status)
     {
+        bool old_mic_status = m_micIsEnabled;
         m_micIsEnabled = rec_status->enabled; //&& rec_status->current_buffer_size > 0;
-        yWarning("We got mic status %d",m_micIsEnabled);
+        if(m_micIsEnabled != old_mic_status)
+            yDebug("We got mic status %d",m_micIsEnabled);
     }
 
     yarp::sig::Sound* data_audio = m_audioRecPort.read(false);

--- a/aux_modules/faceExpression/earsThread.cpp
+++ b/aux_modules/faceExpression/earsThread.cpp
@@ -106,27 +106,11 @@ void EarsThread::run()
         if(data_audio){
             auto vec= data_audio->getChannel(0);
       	    short int max_val = *std::max_element(vec.begin(),vec.end());
-//            max_val = 30000;
+            // max_val = 30000;
             float divider=10000;
             // float divider=32800;
             percentage = fabs((float)max_val / divider);
-            try // this is a BAD solution.
-                ///TODO: Investigate further the crash issue
-            {
-                updateBars(percentage);
-            }
-            catch (const std::exception& e)
-            {
-                yError() << "Error updating bars:" << e.what();
-                if(m_micIsEnabled==false){
-                    m_earBar.setTo(Scalar(0,0,255));
-                    percentage=0.5;
-                }
-                else
-                {
-                    m_earBar.setTo(m_earsDefaultColor);
-                }
-            }
+            updateBars(percentage);
             yInfo() << percentage;
         }
     }
@@ -140,7 +124,8 @@ void EarsThread::run()
 bool EarsThread::updateBars(float percentage)
 {
     lock_guard<mutex> faceguard(m_drawing_mutex);
-
+    if(percentage > 1.00)
+        percentage = 1.00;
     earBar0_len = earBar0_minLen + (earBar0_maxLen - earBar0_minLen) *  percentage;
     earBar1_len = earBar1_minLen + (earBar1_maxLen - earBar1_minLen) *  percentage;
 

--- a/aux_modules/faceExpression/earsThread.cpp
+++ b/aux_modules/faceExpression/earsThread.cpp
@@ -110,7 +110,23 @@ void EarsThread::run()
             float divider=10000;
             // float divider=32800;
             percentage = fabs((float)max_val / divider);
-            updateBars(percentage);
+            try // this is a BAD solution.
+                ///TODO: Investigate further the crash issue
+            {
+                updateBars(percentage);
+            }
+            catch (const std::exception& e)
+            {
+                yError() << "Error updating bars:" << e.what();
+                if(m_micIsEnabled==false){
+                    m_earBar.setTo(Scalar(0,0,255));
+                    percentage=0.5;
+                }
+                else
+                {
+                    m_earBar.setTo(m_earsDefaultColor);
+                }
+            }
             yInfo() << percentage;
         }
     }

--- a/aux_modules/faceExpression/earsThread.hpp
+++ b/aux_modules/faceExpression/earsThread.hpp
@@ -40,7 +40,7 @@ private:
     cv::Scalar              m_earsDefaultColor = cv::Scalar(0, 128, 0);
     cv::Scalar              m_earsCurrentColor = cv::Scalar(0, 128, 0);
 
-    bool m_doBars = false;
+    bool m_doBars = true;
     bool m_drawEnable = true;
     bool m_micIsEnabled = false;
 


### PR DESCRIPTION
The face is now drawn as expected. It uses a pretty cheap solution to avoid a race condition that causes the `faceExpression` thread to crash while updating the ears bars. It needs to be improved. But for the moment being it can be considered a solution.