### PR TITLE
improved VAD adding smoothing and normalized audio

### DIFF
--- a/aux_modules/speechProcessing/sileroVAD/Detector.cpp
+++ b/aux_modules/speechProcessing/sileroVAD/Detector.cpp
@@ -22,6 +22,8 @@ Detector::Detector(int vadFrequency,
                     const std::string modelPath,
                     std::string filteredAudioPortOutName,
                     std::string wakeWordClientPort,
+                    float speechProbEmaAlpha,
+                    float stopThresholdMargin,
                     int8_t vadReenableKeyword):
                     m_vadFrequency(vadFrequency),
                     m_vadGapAllowance(gapAllowance),
@@ -32,6 +34,8 @@ Detector::Detector(int vadFrequency,
                                     vadFrequency == 8000 ? 256 :
                                     throw std::runtime_error("Unsupported sample rate " + std::to_string(vadFrequency)
                                                             + ", must be 8kHz or 16kHz")),
+                    m_speechProbEmaAlpha(std::min(1.0f, std::max(0.0f, speechProbEmaAlpha))),
+                    m_stopThresholdMargin(std::max(0.0f, stopThresholdMargin)),
                     m_context((vadFrequency == 16000) ? 64 : 32, 0),
                     m_currentSoundBufferNorm(m_vadNumSamples, 0),
                     m_currentSoundBuffer(m_vadNumSamples, 0),
@@ -73,12 +77,14 @@ void Detector::init_onnx_model(const std::string& model_path) {
 
 void Detector::reset_states() {
     std::memset(m_state.data(), 0.0f, m_state.size() * sizeof(float));
+    m_smoothedSpeechProb = 0.0f;
+    m_hasSmoothedSpeechProb = false;
 };
 
 void Detector::predict(const std::vector<float> &data) {
     // Create ort tensors
     std::copy(m_context.begin(), m_context.end(), m_input.begin());
-    std::copy(m_currentSoundBuffer.begin(), m_currentSoundBuffer.end(), m_input.begin() + m_context.size());
+    std::copy(data.begin(), data.end(), m_input.begin() + m_context.size());
     Ort::Value input_ort = Ort::Value::CreateTensor<float>(
         m_memory_info, m_input.data(), m_input.size(), m_input_node_dims, 2);
     Ort::Value state_ort = Ort::Value::CreateTensor<float>(
@@ -103,7 +109,22 @@ void Detector::predict(const std::vector<float> &data) {
     float *stateN = m_ort_outputs[1].GetTensorMutableData<float>();
     std::memcpy(m_state.data(), stateN, m_size_state * sizeof(float));
 
-    bool isTalking = speech_prob > m_vadThreshold;
+    if (!m_hasSmoothedSpeechProb)
+    {
+        m_smoothedSpeechProb = speech_prob;
+        m_hasSmoothedSpeechProb = true;
+    }
+    else
+    {
+        m_smoothedSpeechProb =
+            m_speechProbEmaAlpha * speech_prob + (1.0f - m_speechProbEmaAlpha) * m_smoothedSpeechProb;
+    }
+
+    const float startThreshold = m_vadThreshold;
+    const float stopThreshold = std::max(0.0f, m_vadThreshold - m_stopThresholdMargin);
+    const bool isTalking = m_soundDetected ? (m_smoothedSpeechProb > stopThreshold)
+                                           : (m_smoothedSpeechProb > startThreshold);
+
     if (isTalking) {
         yCDebug(VADAUDIOPROCESSOR) << "Voice detected adding to send buffer";
         m_soundDetected = true;
@@ -144,8 +165,8 @@ void Detector::predict(const std::vector<float> &data) {
 
     // copy last part into context for next input
     std::copy(
-        m_currentSoundBuffer.end() - m_context.size(),
-        m_currentSoundBuffer.end(),
+        data.end() - m_context.size(),
+        data.end(),
         m_context.begin()
     );
 };

--- a/aux_modules/speechProcessing/sileroVAD/Detector.h
+++ b/aux_modules/speechProcessing/sileroVAD/Detector.h
@@ -30,6 +30,8 @@ public:
             const std::string modelPath,
             std::string filteredAudioPortOutName,
             std::string wakeWordClientPort,
+            float speechProbEmaAlpha,
+            float stopThresholdMargin,
             int8_t vadReenableKeyword = 0);
     using TypedReaderCallback<yarp::sig::Sound>::onRead;
     void onRead(yarp::sig::Sound& soundReceived) override;
@@ -41,11 +43,15 @@ private:
     const bool m_vadSaveGap;
     const int m_vadNumSamples;
     const int m_vadSavePriorToDetection;
+    const float m_speechProbEmaAlpha;
+    const float m_stopThresholdMargin;
 
     std::deque<std::vector<int16_t>> m_soundToSend;
     std::vector<float> m_currentSoundBufferNorm; // Normalised for silero model
     std::vector<int16_t> m_currentSoundBuffer; // Original for downstream processing/synthesis
     std::vector<float> m_context;
+    float m_smoothedSpeechProb{0.0f};
+    bool m_hasSmoothedSpeechProb{false};
     int m_fillCount; // keep track of up to what index the buffer is full
     int m_vadReenableKeyword; // If 1, reenable the keyword after each audio clip
     bool m_soundDetected{false};

--- a/aux_modules/speechProcessing/sileroVAD/VoiceActivationDetectionModule.cpp
+++ b/aux_modules/speechProcessing/sileroVAD/VoiceActivationDetectionModule.cpp
@@ -75,6 +75,24 @@ bool VoiceActivationDetectionModule::configure(yarp::os::ResourceFinder &rf)
         m_vadSavePriorToDetection = rf.find("vad_save_prior_to_detection").asInt32();
     }
 
+    if (!rf.check("vad_speech_prob_ema_alpha", "vad_speech_prob_ema_alpha"))
+    {
+        yCDebug(VADAUDIOPROCESSORCREATOR) << "Using default 'vad_speech_prob_ema_alpha' parameter of " << VAD_SPEECH_PROB_EMA_ALPHA;
+    }
+    else
+    {
+        m_vadSpeechProbEmaAlpha = rf.find("vad_speech_prob_ema_alpha").asFloat32();
+    }
+
+    if (!rf.check("vad_stop_threshold_margin", "vad_stop_threshold_margin"))
+    {
+        yCDebug(VADAUDIOPROCESSORCREATOR) << "Using default 'vad_stop_threshold_margin' parameter of " << VAD_STOP_THRESHOLD_MARGIN;
+    }
+    else
+    {
+        m_vadStopThresholdMargin = rf.find("vad_stop_threshold_margin").asFloat32();
+    }
+
     if (!rf.check("model_path", "model_path"))
     {
         yCDebug(VADAUDIOPROCESSORCREATOR) << "Using default 'model_path' parameter of " << MODEL_PATH;
@@ -99,6 +117,8 @@ bool VoiceActivationDetectionModule::configure(yarp::os::ResourceFinder &rf)
                                                     m_modelPath,
                                                     filteredAudioPortOutName,
                                                     wakeWordClientPort,
+                                                    m_vadSpeechProbEmaAlpha,
+                                                    m_vadStopThresholdMargin,
                                                     vadReenableKeyword);
 
     m_audioPort.useCallback(*m_audioProcessor);

--- a/aux_modules/speechProcessing/sileroVAD/VoiceActivationDetectionModule.h
+++ b/aux_modules/speechProcessing/sileroVAD/VoiceActivationDetectionModule.h
@@ -19,6 +19,8 @@ private:
     static constexpr bool VAD_SAVE_GAP = true;
     static constexpr int VAD_GAP_ALLOWANCE_DEFAULT = 18; // In packets of 32 ms
     static constexpr int VAD_SAVE_PRIOR_TO_DETECTION = 15; // In packets of 32 ms
+    static constexpr float VAD_SPEECH_PROB_EMA_ALPHA = 0.35f;
+    static constexpr float VAD_STOP_THRESHOLD_MARGIN = 0.15f;
     const std::string MODEL_PATH = "/usr/local/src/robot/silero-vad/src/silero_vad/data/silero_vad.onnx";
 
     std::unique_ptr<SileroVADServer> m_rpcServer;
@@ -29,6 +31,8 @@ private:
     int m_vadGapAllowance{VAD_GAP_ALLOWANCE_DEFAULT};
     bool m_vadSaveGap{VAD_SAVE_GAP};
     int m_vadSavePriorToDetection{VAD_SAVE_PRIOR_TO_DETECTION};
+    float m_vadSpeechProbEmaAlpha{VAD_SPEECH_PROB_EMA_ALPHA};
+    float m_vadStopThresholdMargin{VAD_STOP_THRESHOLD_MARGIN};
     std::string m_modelPath = MODEL_PATH;
     yarp::os::BufferedPort<yarp::sig::Sound> m_audioPort;            /** The input port for receiving the microphone input. **/
     std::shared_ptr<Detector> m_audioProcessor;


### PR DESCRIPTION
Stabilized VAD jittering and false positives. The hard threshold `isTalking = speech_prob > m_vadThreshold` was unreliable so I added a  smoothing speech probability and normalized the input.
To sum up:
- Fixed model input to use normalized data.
- Fixed context update to use normalized data.
- Added smoothing (EMA) on speech_prob.
Added hysteresis:
- start speech at m_vadThreshold
- stop speech at m_vadThreshold - 0.15 (clamped to 0)
- Reset smoothing state in reset_states().

Practical tuning:
- If pauses still split speech too much: increase `vad_stop_threshold_margin` (to. 0.20–0.30).
- If detection reacts too jittery frame-to-frame: lower `vad_speech_prob_ema_alpha` (0.20–0.30).
- If starts are delayed: slightly lower `vad_threshold` or increase `vad_save_prior_to_detection`.