### PR TITLE
Added configuration files for the realsense 

### DIFF
--- a/app/navigation2/conf/realsense2_ir.ini
+++ b/app/navigation2/conf/realsense2_ir.ini
@@ -1,0 +1,1 @@
+config robotInterface/realsense2_ir.xml

--- a/app/navigation2/conf/realsense2_remote_fast.ini
+++ b/app/navigation2/conf/realsense2_remote_fast.ini
@@ -1,0 +1,1 @@
+config robotInterface/realsense2_remote_fast.xml

--- a/app/navigation2/conf/robotInterface/realsense2_ir.xml
+++ b/app/navigation2/conf/robotInterface/realsense2_ir.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<robot name="cer-realsense-cameras" build="2" portprefix="test" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<devices>
+	
+	 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="realsense2dev" type="realsense2">
+	    <group name="SETTINGS">
+	        <param name="depthResolution"> (640 480) </param>
+	        <param name="rgbResolution">  (640 480) </param>
+	        <param name="framerate">    30  </param>
+	        <param name="enableEmitter">    false</param>
+	        <param name="needAlignment">    true</param>
+	        <param name="alignmentFrame">    RGB</param>
+	    </group>
+	     <group name="HW_DESCRIPTION">
+	         <param name="clipPlanes"> (0.2 10.0)</param>
+	     </group>
+	     <group name="QUANT_PARAM">
+	         <param name="depth_quant">2</param>
+	     </group>
+	      <param name="rotateImage180">true</param>
+	      <param name="rotateIRImage180">true</param>
+	      <param name="stereoMode"> true </param>
+     </device>
+	      
+	  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="RGBDWrapperyarp" type="rgbdSensor_nws_yarp">
+	      <param name="period"> 0.033 </param>
+	      <param name="name">    /cer/realsense </param>
+	      <action phase="startup" level="5" type="attach">
+	        <paramlist name="networks">
+	           <elem name="subdevicergbd"> realsense2dev </elem> 
+	         </paramlist>
+	      </action>
+	      <action phase="shutdown" level="5" type="detach" />
+	   </device>
+	   
+	  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="IRCamerasWrapperyarp" type="frameGrabber_nws_yarp">
+	    <param name="period"> 0.033 </param>
+	    <param extern-name="ir_name" name="name">  /depthCamera/ir:o </param>
+	    <param name="capabilities">    RAW </param>
+	    <action phase="startup" level="10" type="attach">
+	      <paramlist name="networks">
+	        <elem name="subdevicergbd"> realsense2dev </elem>
+	      </paramlist>
+	    </action>
+	    <action phase="shutdown" level="15" type="detach" />
+	  </device>
+	
+	</devices>
+</robot>

--- a/app/navigation2/conf/robotInterface/realsense2_remote_fast.xml
+++ b/app/navigation2/conf/robotInterface/realsense2_remote_fast.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="cer-realsense-cameras" build="2" portprefix="test" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <device xmlns:xi="http://www.w3.org/2001/XInclude" name="realsense2dev" type="realsense2">
+            <group name="SETTINGS">
+                <param name="depthResolution"> (640 480) </param>
+                <param name="rgbResolution">  (640 480) </param>
+                <param name="framerate">    30  </param>
+                <param name="enableEmitter">    true</param>
+                <param name="needAlignment">    true</param>
+                <param name="alignmentFrame">    RGB</param>
+            </group>
+            <group name="HW_DESCRIPTION">
+                <param name="clipPlanes"> (0.2 10.0)</param>
+            </group>
+            <group name="QUANT_PARAM">
+                <param name="depth_quant">2</param>
+	        </group>
+            <param name="rotateImage180">true</param>
+        </device>
+        
+        <device xmlns:xi="http://www.w3.org/2001/XInclude" name="RGBDWrapperyarp" type="rgbdSensor_nws_yarp">
+            <param name="period"> 0.033 </param>
+            <param name="name">    /cer/realsense </param>
+            <action phase="startup" level="5" type="attach">
+                <paramlist name="networks">
+                    <elem name="subdevicergbd"> realsense2dev </elem> 
+                </paramlist>
+            </action>
+            <action phase="shutdown" level="5" type="detach" />
+        </device>
+    </devices>
+</robot>


### PR DESCRIPTION
The RealSense can now be launched using three different configurations:
1. realsense2_remote.ini: runs with a period of **0.16** s to reduce the computational load. It is intended for applications that do not require a high update rate.
2. realsense2_remote_fast.ini: uses the same configuration as above, but with a period of **0.033 s**.
3. realsense2_ir.ini: runs with a period of 0.033 s. In addition, **stereo mode** is enabled and the **infrared wrappers** are started.